### PR TITLE
Remove support for INSIDERSASTOKEN

### DIFF
--- a/DetermineArtifactUrl/DetermineArtifactUrl.Helper.ps1
+++ b/DetermineArtifactUrl/DetermineArtifactUrl.Helper.ps1
@@ -7,8 +7,7 @@ function DetermineArtifactUrl {
 
     $artifact = $settings.artifact
     if ($artifact.Contains('{INSIDERSASTOKEN}')) {
-        $artifact = $artifact.replace('{INSIDERSASTOKEN}', '')
-        Write-Host "::Warning::Please update your artifact setting and remove {INSIDERSASTOKEN} from the setting. This is no longer needed."
+        Write-Error "{INSIDERSASTOKEN} is no longer supported in the artifact setting."
     }
 
     Write-Host "Checking artifact setting for repository"

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -288,7 +288,7 @@ try {
         -imageName $imageName `
         -bcAuthContext $authContext `
         -environment $environmentName `
-        -artifact $settings.artifact.replace('{INSIDERSASTOKEN}', '') `
+        -artifact $settings.artifact `
         -vsixFile $settings.vsixFile `
         -companyName $settings.companyName `
         -memoryLimit $settings.memoryLimit `


### PR DESCRIPTION
This pull request includes changes to the `DetermineArtifactUrl.Helper.ps1` and `RunPipeline.ps1` scripts to remove the handling of the `{INSIDERSASTOKEN}` placeholder in artifact settings. The most important changes are summarized below:

### Removal of `{INSIDERSASTOKEN}` handling:

* [`DetermineArtifactUrl/DetermineArtifactUrl.Helper.ps1`](diffhunk://#diff-c7c05ca4853c247d8163b1887ee981f8caf7896a9804b5964c6531e0a265c5bcL10-R10): Replaced the warning message with an error message indicating that `{INSIDERSASTOKEN}` is no longer supported in the artifact setting.
* [`RunPipeline/RunPipeline.ps1`](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cL291-R291): Removed the replacement of `{INSIDERSASTOKEN}` in the artifact setting, as it is no longer needed.