### PR TITLE
Dependencies are added multiple times

### DIFF
--- a/.Internal/AnalyzeRepository.Helper.ps1
+++ b/.Internal/AnalyzeRepository.Helper.ps1
@@ -131,20 +131,27 @@ function AnalyzeRepo {
                             $settings.applicationDependency = $appDep
                         }
                     }
+
+
+                    $allBCDependenciesParam = @{}
+                    if ($skipAppsInPreview -eq $true) {
+                        $allBCDependenciesParam = @{ "skipAppsInPreview" = $true }
+                    }
+
                     if ($appFolder) {
                         $mainAppId = $appJson.id
                         if ($appJson.PSObject.Properties.Name -eq 'Version') {
                             $settings.appJsonVersion = $appJson.version
                         }
 
-                        $foundAppDependencies = @(Get-AppDependencies -appJsonFilePath $appJsonFile -minBcVersion $minBcVersion -includeAppsInPreview !$skipAppsInPreview)
+                        $foundAppDependencies = @(Get-AppDependencies -appJsonFilePath $appJsonFile -minBcVersion $minBcVersion @allBCDependenciesParam)
                         if ($foundAppDependencies) {
                             $settings.appDependencies += Get-DependenciesAsTextString -dependencies $foundAppDependencies
                         }
                         Write-Host "Adding newly found APP dependencies: $($settings.appDependencies)"
                     }
                     elseif ($testFolder) {
-                        $foundTestDependencies = @(Get-AppDependencies -appJsonFilePath $appJsonFile -excludeExtensionID $mainAppId -minBcVersion $minBcVersion -includeAppsInPreview !$skipAppsInPreview)
+                        $foundTestDependencies = @(Get-AppDependencies -appJsonFilePath $appJsonFile -excludeExtensionID $mainAppId -minBcVersion $minBcVersion @allBCDependenciesParam)
                         if ($foundTestDependencies) {
                             $settings.testDependencies += Get-DependenciesAsTextString -dependencies $foundTestDependencies
                         }

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -235,6 +235,7 @@ function Get-AllBCDependencies {
             $dependencyAppJsonContent = Get-AppJsonFile -sourceAppJsonFilePath ($appsLocation + 'app.json')
             
             $dependencyObject = Get-DependencyObject -dependencyFolder $appsLocation -dependencyAppJsonContent $dependencyAppJsonContent
+            Write-Host "Checking if $dependencies constains $dependencyObject"
             if ($dependencies.Add($dependencyObject)) {
                 OutputDebug -Message "Adding dependency: $($dependencyObject.id) from $($dependencyObject.appFile)"
 

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -232,7 +232,7 @@ function Get-AllBCDependencies {
                 $innerDependencies = Get-AllBCDependencies -appFile $dependencyAppJsonContent -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion @allBCDependencies
                 
                 # Add dependencies from the apps (found recursively)
-                if ($innerDependencies -ne @() -and $listOfDependencies -notcontains $innerDependencies) {
+                if ($innerDependencies -ne @() -and $innerDependencies.Count -gt 0) {
                     $listOfDependencies += $innerDependencies
                     OutputDebug -Message "Adding previously found dependencies $innerDependencies"
                 }

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -235,7 +235,7 @@ function Get-AllBCDependencies {
             $dependencyAppJsonContent = Get-AppJsonFile -sourceAppJsonFilePath ($appsLocation + 'app.json')
             
             $dependencyObject = Get-DependencyObject -dependencyFolder $appsLocation -dependencyAppJsonContent $dependencyAppJsonContent
-            Write-Host "Checking if $dependencies constains $dependencyObject"
+            Write-Host "Checking if $($dependencies | ConvertTo-Json) constains $dependencyObject"
             if ($dependencies.Add($dependencyObject)) {
                 OutputDebug -Message "Adding dependency: $($dependencyObject.id) from $($dependencyObject.appFile)"
 

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -21,7 +21,7 @@ function Get-AppDependencies {
             if ($includeAppsInPreview -eq $true) {
                 $allBCDependenciesParam = @{ "includeAppsInPreview" = $true }
             }
-            $dependenciesAsHashSet = Get-AllBCDependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
+            [System.Collections.Generic.HashSet[PSCustomObject]] $dependenciesAsHashSet = Get-AllBCDependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
             $dependencies = $dependenciesAsHashSet.ToArray()
             Write-Host "App dependencies: $dependencies"
             return $dependencies

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -21,7 +21,7 @@ function Get-AppDependencies {
             if ($includeAppsInPreview -eq $true) {
                 $allBCDependenciesParam = @{ "includeAppsInPreview" = $true }
             }
-            Get-AllBCDependencies -dependencies $dependenciesAsHashSet -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
+            $dependenciesAsHashSet = Get-AllBCDependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
             $dependencies = $dependenciesAsHashSet.ToArray()
             Write-Host "App dependencies: $dependencies"
             return $dependencies
@@ -228,9 +228,10 @@ function Get-AllBCDependencies {
             $dependencyAppJsonContent = Get-AppJsonFile -sourceAppJsonFilePath ($appsLocation + 'app.json')
             
             # Process inner dependencies first
-            Get-AllBCDependencies -dependencies $dependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $dependencyAppJsonContent @allBCDependencies 
+            $dependencies = Get-AllBCDependencies -dependencies $dependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $dependencyAppJsonContent @allBCDependencies 
         }
     }
+    return $dependencies
 }
 
 function Get-DependencyObject {

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -231,6 +231,7 @@ function Get-AllBCDependencies {
                 $dependencyAppJsonContent = Get-AppJsonFile -sourceAppJsonFilePath ($appsLocation + 'app.json');
                 $innerDependencies = Get-AllBCDependencies -appFile $dependencyAppJsonContent -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion @allBCDependencies
                 
+                Write-Host "No. of inner dependencies $($innerDependencies.Count)"
                 # Add dependencies from the apps (found recursively)
                 if ($innerDependencies -ne @() -and $innerDependencies.Count -gt 0) {
                     $listOfDependencies += $innerDependencies

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -232,9 +232,9 @@ function Get-AllBCDependencies {
                 $innerDependencies = Get-AllBCDependencies -appFile $dependencyAppJsonContent -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion @allBCDependencies
                 
                 # Add dependencies from the apps (found recursively)
-                if ($innerDependencies -ne @()) {
+                if ($innerDependencies -ne @() -and $listOfDependencies -notcontains $innerDependencies) {
                     $listOfDependencies += $innerDependencies
-                    OutputDebug -Message "Adding previously found dependencies..."
+                    OutputDebug -Message "Adding previously found dependencies $innerDependencies"
                 }
 
                 # Add the current app

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -21,7 +21,7 @@ function Get-AppDependencies {
             if ($includeAppsInPreview -eq $true) {
                 $allBCDependenciesParam = @{ "includeAppsInPreview" = $true }
             }
-            $dependenciesAsHashSet = Get-AllBCDependencies -appFile $appFileContent -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion @allBCDependenciesParam
+            Get-AllBCDependencies -dependencies $dependenciesAsHashSet -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
             $dependencies = $dependenciesAsHashSet.ToArray()
             Write-Host "App dependencies: $dependencies"
             return $dependencies

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -235,8 +235,8 @@ function Get-AllBCDependencies {
             $dependencyAppJsonContent = Get-AppJsonFile -sourceAppJsonFilePath ($appsLocation + 'app.json')
             
             $dependencyObject = Get-DependencyObject -dependencyFolder $appsLocation -dependencyAppJsonContent $dependencyAppJsonContent
-            Write-Host "Checking if $($dependencies | ConvertTo-Json) constains $dependencyObject"
-            if ($dependencies.Add($dependencyObject)) {
+            if (-not ($dependencies | Where-Object { $_.appFile -eq $dependencyObject.appFile })) {
+                $dependencies.Add($dependencyObject)
                 OutputDebug -Message "Adding dependency: $($dependencyObject.id) from $($dependencyObject.appFile)"
 
                 # Process inner dependencies first

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -21,7 +21,7 @@ function Get-AppDependencies {
             if ($includeAppsInPreview -eq $true) {
                 $allBCDependenciesParam = @{ "includeAppsInPreview" = $true }
             }
-            [HashSet[PSCustomObject]] $dependenciesAsHashSet = Get-AllBCDependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
+            [System.Collections.Generic.HashSet[PSCustomObject]] $dependenciesAsHashSet = Get-AllBCDependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
             $dependencies = $dependenciesAsHashSet.ToArray()
             Write-Host "App dependencies: $dependencies"
             return $dependencies
@@ -202,7 +202,7 @@ function Get-AppTargetFilePathWithoutReleaseType {
 function Get-AllBCDependencies {
     [CmdletBinding()]
     Param (
-        [HashSet[PSCustomObject]] $dependencies = $null,
+        [System.Collections.Generic.HashSet[PSCustomObject]] $dependencies = $null,
         [string] $excludeExtensionID = "",
         [switch] $includeAppsInPreview,
         [version] $minBcVersion,
@@ -210,7 +210,7 @@ function Get-AllBCDependencies {
     )
 
     if ($null -eq $dependencies) {
-        $dependencies = [HashSet[PSCustomObject]]::new()
+        $dependencies = [System.Collections.Generic.HashSet[PSCustomObject]]::new()
     }
     
     $appTargetFilePathParam = @{}
@@ -231,7 +231,7 @@ function Get-AllBCDependencies {
                 OutputDebug -Message "Adding dependency: $($dependencyObject.id) from $($dependencyObject.appFile)"
 
                 # Process inner dependencies first
-                [HashSet[PSCustomObject]] $dependencies = Get-AllBCDependencies -dependencies $dependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $dependencyAppJsonContent @allBCDependencies 
+                [System.Collections.Generic.HashSet[PSCustomObject]] $dependencies = Get-AllBCDependencies -dependencies $dependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $dependencyAppJsonContent @allBCDependencies 
             }
             else {
                 OutputDebug -Message "Dependency already exists: $($dependencyObject.id) from $($dependencyObject.appFile)"

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -21,7 +21,7 @@ function Get-AppDependencies {
             if ($includeAppsInPreview -eq $true) {
                 $allBCDependenciesParam = @{ "includeAppsInPreview" = $true }
             }
-            $dependenciesAsHashSet = Get-AllBCDependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
+            [HashSet[PSCustomObject]] $dependenciesAsHashSet = Get-AllBCDependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
             $dependencies = $dependenciesAsHashSet.ToArray()
             Write-Host "App dependencies: $dependencies"
             return $dependencies
@@ -202,7 +202,7 @@ function Get-AppTargetFilePathWithoutReleaseType {
 function Get-AllBCDependencies {
     [CmdletBinding()]
     Param (
-        [System.Collections.Generic.HashSet[PSCustomObject]] $dependencies = $null,
+        [HashSet[PSCustomObject]] $dependencies = $null,
         [string] $excludeExtensionID = "",
         [switch] $includeAppsInPreview,
         [version] $minBcVersion,
@@ -210,7 +210,7 @@ function Get-AllBCDependencies {
     )
 
     if ($null -eq $dependencies) {
-        $dependencies = [System.Collections.Generic.HashSet[PSCustomObject]]::new()
+        $dependencies = [HashSet[PSCustomObject]]::new()
     }
     
     $appTargetFilePathParam = @{}
@@ -231,7 +231,7 @@ function Get-AllBCDependencies {
                 OutputDebug -Message "Adding dependency: $($dependencyObject.id) from $($dependencyObject.appFile)"
 
                 # Process inner dependencies first
-                $dependencies = Get-AllBCDependencies -dependencies $dependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $dependencyAppJsonContent @allBCDependencies 
+                [HashSet[PSCustomObject]] $dependencies = Get-AllBCDependencies -dependencies $dependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $dependencyAppJsonContent @allBCDependencies 
             }
             else {
                 OutputDebug -Message "Dependency already exists: $($dependencyObject.id) from $($dependencyObject.appFile)"

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -6,7 +6,7 @@ function Get-AppDependencies {
         [string] $excludeExtensionID = $null,
         [Parameter(Mandatory = $true)]
         [version] $minBcVersion,
-        [switch] $includeAppsInPreview
+        [switch] $skipAppsInPreview
     )
     Process {
         Write-Host "Identifying App dependencies..."
@@ -21,8 +21,8 @@ function Get-AppDependencies {
             
             # Get all dependencies for specific extension
             $allBCDependenciesParam = @{}
-            if ($includeAppsInPreview -eq $true) {
-                $allBCDependenciesParam = @{ "includeAppsInPreview" = $true }
+            if ($skipAppsInPreview -eq $true) {
+                $allBCDependenciesParam = @{ "skipAppsInPreview" = $true }
             }
             $dependenciesAsHashSet = Get-AllBCDependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $appFileContent  @allBCDependenciesParam
 
@@ -91,7 +91,7 @@ function Get-AppTargetFilePath {
     Param (
         [string] $extensionID,
         [string] $extensionVersion,
-        [switch] $includeAppsInPreview,
+        [switch] $skipAppsInPreview,
         [version] $minBcVersion,
         [string] $findExisting = $true
     )
@@ -212,7 +212,7 @@ function Get-AllBCDependencies {
     Param (
         [System.Collections.Generic.HashSet[PSCustomObject]] $dependencies = $null,
         [string] $excludeExtensionID = "",
-        [switch] $includeAppsInPreview,
+        [switch] $skipAppsInPreview,
         [version] $minBcVersion,
         $appFile
     )
@@ -223,9 +223,9 @@ function Get-AllBCDependencies {
     
     $appTargetFilePathParam = @{}
     $allBCDependencies = @{}
-    if ($includeAppsInPreview) {
-        $appTargetFilePathParam = @{ "includeAppsInPreview" = $true }
-        $allBCDependencies = @{ "includeAppsInPreview" = $true }
+    if ($skipAppsInPreview) {
+        $appTargetFilePathParam = @{ "skipAppsInPreview" = $true }
+        $allBCDependencies = @{ "skipAppsInPreview" = $true }
     }
 
     foreach ($dependency in $appFile.dependencies) {

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -21,9 +21,9 @@ function Get-AppDependencies {
             if ($includeAppsInPreview -eq $true) {
                 $allBCDependenciesParam = @{ "includeAppsInPreview" = $true }
             }
-            $dependencies = @(Get-AllBCDependencies -appFile $appFileContent -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion @allBCDependenciesParam)
+            $dependenciesAsHashSet = Get-AllBCDependencies -appFile $appFileContent -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion @allBCDependenciesParam
+            $dependencies = $dependenciesAsHashSet.ToArray()
             Write-Host "App dependencies: $dependencies"
-
             return $dependencies
         }
     }
@@ -202,51 +202,35 @@ function Get-AppTargetFilePathWithoutReleaseType {
 function Get-AllBCDependencies {
     [CmdletBinding()]
     Param (
+        [System.Collections.Generic.HashSet[PSCustomObject]] $dependencies = $null,
         [string] $excludeExtensionID = "",
         [switch] $includeAppsInPreview,
         [version] $minBcVersion,
         $appFile
     )
 
-    $listOfDependencies = @()
+    if ($null -eq $dependencies) {
+        $dependencies = [System.Collections.Generic.HashSet[PSCustomObject]]::new()
+    }
+    
+    $appTargetFilePathParam = @{}
+    $allBCDependencies = @{}
+    if ($includeAppsInPreview) {
+        $appTargetFilePathParam = @{ "includeAppsInPreview" = $true }
+        $allBCDependencies = @{ "includeAppsInPreview" = $true }
+    }
+
     foreach ($dependency in $appFile.dependencies) {
-        if ($dependency.publisher -ne 'Microsoft') {
-            OutputDebug -Message "Searching for dependencies for app $($dependency.name) ($($dependency.id))"
-            if ($excludeExtensionID -ne '' -and $excludeExtensionID -ne $null) {
-                OutputDebug -Message "Verifying the dependency is not to be excluded ($excludeExtensionID)"
-            }
-            if ($dependency.id -eq $excludeExtensionID) {
-                Write-Host "Skipping dependency $($dependency.name) ($($dependency.id))"
-            }
-            else {
-                $appTargetFilePathParam = @{}
-                $allBCDependencies = @{}
-                if ($includeAppsInPreview -eq $true) {
-                    $appTargetFilePathParam = @{ "includeAppsInPreview" = $true }
-                    $allBCDependencies = @{ "includeAppsInPreview" = $true }
-                }
-
-                OutputDebug -Message "Verifying id: $($dependency.id) , name: $($dependency.name) , version: $($dependency.version)"
-                $appsLocation = Get-AppTargetFilePath -extensionID $dependency.id -extensionVersion $dependency.version -minBcVersion $minBcVersion @appTargetFilePathParam
-                $dependencyAppJsonContent = Get-AppJsonFile -sourceAppJsonFilePath ($appsLocation + 'app.json');
-                $innerDependencies = Get-AllBCDependencies -appFile $dependencyAppJsonContent -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion @allBCDependencies
-                
-                Write-Host "No. of inner dependencies $($innerDependencies.Count)"
-                # Add dependencies from the apps (found recursively)
-                if ($innerDependencies -ne @() -and $innerDependencies.Count -gt 0) {
-                    $listOfDependencies += $innerDependencies
-                    OutputDebug -Message "Adding previously found dependencies $innerDependencies"
-                }
-
-                # Add the current app
-                $currentFileInfo = Get-DependencyObject -dependencyFolder $appsLocation -dependencyAppJsonContent $dependencyAppJsonContent
-                if ($listOfDependencies.id -notcontains $currentFileInfo.id) {
-                    $listOfDependencies += $currentFileInfo
-                }
-            }
+        $dependencyObject = Get-DependencyObject -dependencyFolder $appsLocation -dependencyAppJsonContent $dependencyAppJsonContent
+        if ($dependency.publisher -ne 'Microsoft' -and $dependency.id -ne $excludeExtensionID -and $dependencies.Add($dependencyObject)) {
+            OutputDebug -Message "Processing dependency: $($dependency.name) ($($dependency.id))"
+            $appsLocation = Get-AppTargetFilePath -extensionID $dependency.id -extensionVersion $dependency.version -minBcVersion $minBcVersion @appTargetFilePathParam
+            $dependencyAppJsonContent = Get-AppJsonFile -sourceAppJsonFilePath ($appsLocation + 'app.json')
+            
+            # Process inner dependencies first
+            Get-AllBCDependencies -dependencies $dependencies -excludeExtensionID $excludeExtensionID -minBcVersion $minBcVersion -appFile $dependencyAppJsonContent @allBCDependencies 
         }
     }
-    return $listOfDependencies;
 }
 
 function Get-DependencyObject {

--- a/DeployToCloud/DeployToCloud.ps1
+++ b/DeployToCloud/DeployToCloud.ps1
@@ -87,7 +87,7 @@ try {
     Write-Host "- $([System.IO.Path]::GetFileName($appFile))"
 
     if ($deploymentSettings.dependencyInstallMode -ne "ignore") {
-        $dependenciesToDeploy = Get-AppDependencies -appJsonFilePath $appJsonFile -minBcVersion $minBcVersion -includeAppsInPreview $includeAppsInPreview
+        $dependenciesToDeploy = Get-AppDependencies -appJsonFilePath $appJsonFile -minBcVersion $minBcVersion
         if ($dependenciesToDeploy) {
             $dependencies += $dependenciesToDeploy
         }

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -320,6 +320,8 @@ try {
         $runAlPipelineParams["preprocessorsymbols"] += $settings.preprocessorSymbols
     }
 
+    Write-Error 'STOP'
+
     $workflowName = "$ENV:BUILD_TRIGGEREDBY_DEFINITIONNAME".Trim()
     Write-Host "Invoke Run-AlPipeline with buildmode $buildMode"
     Run-AlPipeline @runAlPipelineParams `

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -320,8 +320,6 @@ try {
         $runAlPipelineParams["preprocessorsymbols"] += $settings.preprocessorSymbols
     }
 
-    Write-Error 'STOP'
-
     $workflowName = "$ENV:BUILD_TRIGGEREDBY_DEFINITIONNAME".Trim()
     Write-Host "Invoke Run-AlPipeline with buildmode $buildMode"
     Run-AlPipeline @runAlPipelineParams `


### PR DESCRIPTION
This pull request includes changes to the PowerShell scripts for analyzing and finding dependencies in the repository. The main changes involve renaming a parameter and adding support for handling dependencies as a hash set.

### Changes to dependency handling:

* [`.Internal/AnalyzeRepository.Helper.ps1`](diffhunk://#diff-95168f8bbef30e64eed2c0930da52890fbecf4a86ad631d7c24c8e41bbf3acb8R134-R154): Added support for skipping apps in preview by introducing the `allBCDependenciesParam` parameter. Updated the `Get-AppDependencies` calls to use this new parameter.

* [`.Internal/FindDependencies.Helper.ps1`](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248R2-R9): Renamed the `includeAppsInPreview` parameter to `skipAppsInPreview` and updated its usage throughout the script. [[1]](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248R2-R9) [[2]](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248L21-R34) [[3]](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248L86-R94) [[4]](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248R213-R250)

### Improvements to dependency processing:

* [`.Internal/FindDependencies.Helper.ps1`](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248R213-R250): Modified the `Get-AllBCDependencies` function to handle dependencies as a hash set, ensuring no duplicate dependencies are processed.

### Debugging enhancements:

* [`.Internal/FindDependencies.Helper.ps1`](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248L264-R266): Updated debug messages to provide clearer information about the creation and addition of dependency objects.

### Deployment script update:

* [`DeployToCloud/DeployToCloud.ps1`](diffhunk://#diff-968e4091481686f5fae278ed6e905568f4303e5e344a091e65111127e4cff189L90-R90): Removed the `includeAppsInPreview` parameter from the `Get-AppDependencies` call to align with the updated function signature.