### PR TITLE
Apply App.json Updated in NuGet Build

### DIFF
--- a/.Internal/ApplyAppJsonUpdates.Helper.ps1
+++ b/.Internal/ApplyAppJsonUpdates.Helper.ps1
@@ -1,0 +1,80 @@
+. (Join-Path -Path $PSScriptRoot -ChildPath "WriteOutput.Helper.ps1" -Resolve)
+. (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\WriteSettings.Helper.ps1" -Resolve)
+
+function Update-AppJson {
+    Param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$settings
+    )
+    RemoveInternalsVisibleTo -settings $settings
+    OverrideResourceExposurePolicy -settings $settings
+}
+
+function RemoveInternalsVisibleTo {
+    Param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$settings
+    )
+
+    if ($settings.removeInternalsVisibleTo) {
+        $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "App\app.json"
+        $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
+        
+        $settingExists = [bool] ($appFileJson.PSObject.Properties.Name -eq 'internalsVisibleTo')
+        if (!$settingExists) {
+            OutputDebug -Message "Setting 'internalsVisibleTo' not found in app.json - nothing to remove"
+        }
+        else {
+            if ($appFileJson.internalsVisibleTo.Count -eq 0) {
+                OutputDebug -Message "'internalsVisibleTo' is blank - nothing to remove"
+            }
+            else {
+                $appFileJson.internalsVisibleTo = @()
+                Write-Host "Removing 'internalsVisibleTo' from app.json by replacing with empty array"
+            }
+        }
+        Set-JsonContentLF -Path $appJsonFilePath -object $appFileJson
+    }
+}
+
+function OverrideResourceExposurePolicy {
+    Param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$settings
+    )
+
+    if ($settings.overrideResourceExposurePolicy) {
+        $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "App\app.json"
+        $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
+    
+        $resourceExposurePolicySpecified = [bool] ($appFileJson.PSObject.Properties.Name -eq 'resourceExposurePolicy')
+        if (!$resourceExposurePolicySpecified) {
+            $resourceExposurePolicy = [PSCustomObject]@{}
+            OutputDebug -Message "Setting 'resourceExposurePolicy' using settings from pipeline. No existing setting found in app.json"
+        }
+        else {
+            $resourceExposurePolicy = $appFileJson.resourceExposurePolicy
+            OutputDebug -Message "Setting 'resourceExposurePolicy' using settings from pipeline and existing app.json setting"
+        }
+
+        if ($settings.Contains('allowDebugging')) {
+            $resourceExposurePolicy | Add-Member -MemberType NoteProperty -Name 'allowDebugging' -Value $settings.allowDebugging -Force
+            OutputDebug -Message "Setting 'allowDebugging' from $($appFileJson.resourceExposurePolicy.allowDebugging) to $($settings.allowDebugging)"
+        }
+        if ($settings.Contains('allowDownloadingSource')) {
+            $resourceExposurePolicy | Add-Member -MemberType NoteProperty -Name 'allowDownloadingSource' -Value $settings.allowDownloadingSource -Force
+            OutputDebug -Message "Setting 'allowDownloadingSource' from $($appFileJson.resourceExposurePolicy.allowDownloadingSource) to $($settings.allowDownloadingSource)"
+        }
+        if ($settings.Contains('includeSourceInSymbolFile')) {
+            $resourceExposurePolicy | Add-Member -MemberType NoteProperty -Name 'includeSourceInSymbolFile' -Value $settings.includeSourceInSymbolFile -Force
+            OutputDebug -Message "Setting 'includeSourceInSymbolFile' from $($appFileJson.resourceExposurePolicy.includeSourceInSymbolFile) to $($settings.includeSourceInSymbolFile)"
+        }
+        if ($settings.Contains('applyToDevExtension')) {
+            $resourceExposurePolicy | Add-Member -MemberType NoteProperty -Name 'applyToDevExtension' -Value $settings.applyToDevExtension -Force
+            OutputDebug -Message "Setting 'applyToDevExtension' from $($appFileJson.resourceExposurePolicy.applyToDevExtension) to $($settings.applyToDevExtension)"
+        }
+    
+        $appFileJson | Add-Member -MemberType NoteProperty -Name 'resourceExposurePolicy' -Value $resourceExposurePolicy -Force
+        Set-JsonContentLF -Path $appJsonFilePath -object $appFileJson
+    }
+}

--- a/.Internal/ApplyAppJsonUpdates.Helper.ps1
+++ b/.Internal/ApplyAppJsonUpdates.Helper.ps1
@@ -1,5 +1,6 @@
 . (Join-Path -Path $PSScriptRoot -ChildPath "WriteOutput.Helper.ps1" -Resolve)
-. (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\WriteSettings.Helper.ps1" -Resolve)
+. (Join-Path -Path $PSScriptRoot -ChildPath "WriteSettings.Helper.ps1" -Resolve)
+. (Join-Path -Path $PSScriptRoot -ChildPath "FindDependencies.Helper.ps1" -Resolve)
 
 function Update-AppJson {
     Param(

--- a/BuildWithNuget/BuildWithNuget.Helper.ps1
+++ b/BuildWithNuget/BuildWithNuget.Helper.ps1
@@ -1,0 +1,40 @@
+function Assert-Prerequisites {
+    if (!$ENV:AL_NUGETINITIALIZED) {
+        throw "Nuget not initialized - make sure that the InitNuget pipeline step is configured to run before this step."
+    }
+}
+
+function Get-BuildParameters {
+    param (
+        [string]$baseRepoFolder,
+        [string]$baseAppFolder,
+        [string]$packageCachePath,
+        [object]$appFileJson
+    )
+
+    $AppFileName = (("{0}_{1}_{2}.app" -f $appFileJson.publisher, $appFileJson.name, $appFileJson.version).Split([System.IO.Path]::GetInvalidFileNameChars()) -join '')
+    $outputPath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath ".output"
+
+    return @(
+        "/project:`"$baseAppFolder`"",
+        "/packagecachepath:$packageCachePath",
+        "/out:`"$outputPath\$AppFileName`"",
+        "/loglevel:Warning"
+    )
+}
+
+function Invoke-AlCompiler {
+    param([array]$Parameters)
+
+    Write-Host "Using parameters:"
+    $Parameters | ForEach-Object { Write-Host "  $_" }
+
+    Push-Location
+    try {
+        Set-Location $ENV:AL_BCDEVTOOLSFOLDER
+        & .\alc.exe $Parameters
+    }
+    finally {
+        Pop-Location
+    }
+}

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -14,7 +14,7 @@ Param(
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\RunPipeline\RunPipeline.Helper.ps1" -Resolve)
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\BCContainerHelper.Helper.ps1" -Resolve)
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\WriteOutput.Helper.ps1" -Resolve)
-. (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\WriteSettings.Helper.ps1" -Resolve)
+. (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\ApplyAppJsonUpdates.Helper.ps1" -Resolve)
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\AnalyzeRepository.Helper.ps1" -Resolve)
 
 $containerBaseFolder = $null
@@ -229,60 +229,7 @@ try {
         }
     }
 
-    if ($settings.removeInternalsVisibleTo) {
-        $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "App\app.json"
-        $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
-        
-        $settingExists = [bool] ($appFileJson.PSObject.Properties.Name -eq 'internalsVisibleTo')
-        if (!$settingExists) {
-            OutputDebug -Message "Setting 'internalsVisibleTo' not found in app.json - nothing to remove"
-        }
-        else {
-            if ($appFileJson.internalsVisibleTo.Count -eq 0) {
-                OutputDebug -Message "'internalsVisibleTo' is blank - nothing to remove"
-            }
-            else {
-                $appFileJson.internalsVisibleTo = @()
-                Write-Host "Removing 'internalsVisibleTo' from app.json by replacing with empty array"
-            }
-        }
-        Set-JsonContentLF -Path $appJsonFilePath -object $appFileJson
-    }
-
-    if ($settings.overrideResourceExposurePolicy) {
-        $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "App\app.json"
-        $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
-        
-        $resourceExposurePolicySpecified = [bool] ($appFileJson.PSObject.Properties.Name -eq 'resourceExposurePolicy')
-        if (!$resourceExposurePolicySpecified) {
-            $resourceExposurePolicy = [PSCustomObject]@{}
-            OutputDebug -Message "Setting 'resourceExposurePolicy' using settings from pipeline. No existing setting found in app.json"
-        }
-        else {
-            $resourceExposurePolicy = $appFileJson.resourceExposurePolicy
-            OutputDebug -Message "Setting 'resourceExposurePolicy' using settings from pipeline and existing app.json setting"
-        }
-
-        if ($settings.Contains('allowDebugging')) {
-            $resourceExposurePolicy | Add-Member -MemberType NoteProperty -Name 'allowDebugging' -Value $settings.allowDebugging -Force
-            OutputDebug -Message "Setting 'allowDebugging' from $($appFileJson.resourceExposurePolicy.allowDebugging) to $($settings.allowDebugging)"
-        }
-        if ($settings.Contains('allowDownloadingSource')) {
-            $resourceExposurePolicy | Add-Member -MemberType NoteProperty -Name 'allowDownloadingSource' -Value $settings.allowDownloadingSource -Force
-            OutputDebug -Message "Setting 'allowDownloadingSource' from $($appFileJson.resourceExposurePolicy.allowDownloadingSource) to $($settings.allowDownloadingSource)"
-        }
-        if ($settings.Contains('includeSourceInSymbolFile')) {
-            $resourceExposurePolicy | Add-Member -MemberType NoteProperty -Name 'includeSourceInSymbolFile' -Value $settings.includeSourceInSymbolFile -Force
-            OutputDebug -Message "Setting 'includeSourceInSymbolFile' from $($appFileJson.resourceExposurePolicy.includeSourceInSymbolFile) to $($settings.includeSourceInSymbolFile)"
-        }
-        if ($settings.Contains('applyToDevExtension')) {
-            $resourceExposurePolicy | Add-Member -MemberType NoteProperty -Name 'applyToDevExtension' -Value $settings.applyToDevExtension -Force
-            OutputDebug -Message "Setting 'applyToDevExtension' from $($appFileJson.resourceExposurePolicy.applyToDevExtension) to $($settings.applyToDevExtension)"
-        }
-        
-        $appFileJson | Add-Member -MemberType NoteProperty -Name 'resourceExposurePolicy' -Value $resourceExposurePolicy -Force
-        Set-JsonContentLF -Path $appJsonFilePath -object $appFileJson
-    }
+    Update-AppJson -settings $settings
 
     "enableTaskScheduler",
     "assignPremiumPlan",


### PR DESCRIPTION
This pull request includes significant updates to several PowerShell scripts to enhance functionality and improve code organization. The most important changes involve the addition of new helper functions, refactoring existing code to utilize these helpers, and updating the `app.json` configuration based on pipeline settings.

### Enhancements to functionality:

* [`.Internal/ApplyAppJsonUpdates.Helper.ps1`](diffhunk://#diff-9cde32eeb804a6d5e07db43493c0da4fe3e1f215f8d921ec967a6e8b74e71295R1-R81): Added new functions `Update-AppJson`, `RemoveInternalsVisibleTo`, and `OverrideResourceExposurePolicy` to manage `app.json` configuration updates based on provided settings.
* [`BuildWithNuget/BuildWithNuget.Helper.ps1`](diffhunk://#diff-5740b015b5566ebbdb5cef57b6ad1a0027132d713d5f0a5c5fb77ab336db4e89R1-R40): Introduced new functions `Assert-Prerequisites`, `Get-BuildParameters`, and `Invoke-AlCompiler` to check prerequisites, generate build parameters, and invoke the AL compiler respectively.

### Code refactoring for better organization:

* [`BuildWithNuget/BuildWithNuget.ps1`](diffhunk://#diff-d43fd80f182a96aa17fbf1f5ad25bed30f65918a5001f57533ff35108a937470L1-R26): Refactored to use the newly added helper functions from `BuildWithNuget.Helper.ps1` and `ApplyAppJsonUpdates.Helper.ps1`, replacing inline code for better readability and maintainability.
* [`RunPipeline/RunPipeline.ps1`](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cL17-R17): Updated to source `ApplyAppJsonUpdates.Helper.ps1` instead of `WriteSettings.Helper.ps1` and refactored to use `Update-AppJson` function for updating `app.json` settings. [[1]](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cL17-R17) [[2]](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cL232-R232)