### PR TITLE
Validate Against the Last Release

### DIFF
--- a/.Internal/AnalyzeRepository.Helper.ps1
+++ b/.Internal/AnalyzeRepository.Helper.ps1
@@ -149,6 +149,30 @@ function AnalyzeRepo {
                             $settings.appDependencies += Get-DependenciesAsTextString -dependencies $foundAppDependencies
                         }
                         Write-Host "Adding newly found APP dependencies: $($settings.appDependencies)"
+
+                        if (!$settings.skipUpgrade) {
+                            Write-Host "Locating previous release"      
+                            try {
+                                $latestRelease = Get-LatestRelease -appId $mainAppId 
+                                if ($latestRelease) {
+                                    Write-Host "Using $latestRelease as previous release"
+                                    $settings.previousRelease += $latestRelease
+                                }
+                                else {
+                                    OutputWarning -message "No previous release found"
+                                }
+                            }
+                            catch {
+                                Write-Host $_.Exception -ForegroundColor Red
+                                Write-Host $_.ScriptStackTrace
+                                Write-Host $_.PSMessageDetails
+    
+                                Write-Error "Error trying to locate previous release. See previous lines for details."
+                            }
+                        }
+                        else {
+                            Write-Host "Skipping upgrade check"
+                        }
                     }
                     elseif ($testFolder) {
                         $foundTestDependencies = @(Get-AppDependencies -appJsonFilePath $appJsonFile -excludeExtensionID $mainAppId -minBcVersion $minBcVersion @allBCDependenciesParam)

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -136,8 +136,14 @@ function Get-AppTargetFilePath {
     if ([version]$latestExistingVersion -lt [version]$extensionVersion) {
         Write-Error "Cannot find version $extensionVersion for $extensionID. Latest existing version is $latestExistingVersion."
     }
-    OutputDebug -Message "Using version $latestExistingVersion for extension $extensionID";
-    return "$basePath\apps\$releaseTypeFolder\$extensionID\$latestExistingVersion\";
+
+    OutputDebug -Message "Looking for version $latestExistingVersion for extension $extensionID for all BC versions";
+    $versionFolder = Get-ChildItem ("$basePath\apps\$releaseTypeFolder\$extensionID\") -Directory | Where-Object { $_.Name.StartsWith($latestExistingVersion) } | Select-Object -First 1
+    if (-not $versionFolder) {
+        Write-Error "Cannot find version folder starting with $latestExistingVersion for $extensionID in $basePath\apps\$releaseTypeFolder\$extensionID\"
+    }
+    OutputDebug -Message "Using version $($versionFolder.Name) for extension $extensionID";
+    return "$basePath\apps\$releaseTypeFolder\$extensionID\$($versionFolder.Name)\"
 }
 function Get-ReleaseTypeFolderName {
     [CmdletBinding()]

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -28,13 +28,26 @@ function Get-AppDependencies {
 
             $dependencies = if ($dependenciesAsHashSet -is [System.Collections.Generic.HashSet[PSCustomObject]]) {
                 $dependenciesAsHashSet.ToArray()
-            } else {
+            }
+            else {
                 @($dependenciesAsHashSet)
             }
             Write-Host "App dependencies: $dependencies"
             return $dependencies
         }
     }
+}
+function Get-LatestRelease {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $true)]
+        [string] $appId
+    )
+
+    $appFolder = Get-AppTargetFilePath -extensionID $appId -skipAppsInPreview
+    $appJsonContent = Get-AppJsonFile -sourceAppJsonFilePath ($appFolder + 'app.json')
+    $appFilePath = $appFolder + (Get-AppFileName -publisher $appJsonContent.publisher -name $appJsonContent.name -version $appJsonContent.version)
+    return $appFilePath
 }
 function Get-AppJsonFile {
     [CmdletBinding()]
@@ -89,40 +102,37 @@ function Get-AppFileName {
 function Get-AppTargetFilePath {
     [CmdletBinding()]
     Param (
+        [Parameter(Mandatory = $true)]
         [string] $extensionID,
-        [string] $extensionVersion,
-        [switch] $skipAppsInPreview,
-        [version] $minBcVersion,
-        [string] $findExisting = $true
+        [version] $minBcVersion = '0.0.0.0',
+        [version] $extensionVersion = '0.0.0.0',
+        [switch] $skipAppsInPreview
     )
 
     $settings = $ENV:AL_SETTINGS | ConvertFrom-Json
     $basePath = $settings.writableFolderPath
 
+    [version]$latestPublicVersion = Get-LatestVersion -extensionID $extensionID -minBcVersion $minBcVersion -releaseType 'public'
+    $latestExistingVersion = $latestPublicVersion
+
     $releaseTypeFolderParam = @{}
-    if ($skipAppsInPreview -eq $true) {
+    if ($skipAppsInPreview -eq $false) {
         [version]$latestPreviewVersion = Get-LatestVersion -extensionID $extensionID -minBcVersion $minBcVersion -releaseType 'preview'
-        [version]$latestPublicVersion = Get-LatestVersion -extensionID $extensionID -minBcVersion $minBcVersion -releaseType 'public'
-        $latestExistingVersion = $latestPublicVersion
         if ([version]::Parse($latestPreviewVersion) -gt [version]::Parse($latestPublicVersion)) {
-            $skipAppsInPreview = $false
             $latestExistingVersion = $latestPreviewVersion
             $releaseTypeFolderParam = @{ "isPreview" = $true }
         }
     }
     $releaseTypeFolder = Get-ReleaseTypeFolderName @releaseTypeFolderParam
 
-    if ($findExisting -ne 'true') {
-        $targetFilePath = "$basePath\apps\$releaseTypeFolder\$extensionID\$extensionVersion-BC$minBcVersion\"
-        OutputDebug -Message "Using '$targetFilePath' regardless if the extension exists or not"
-        return $targetFilePath
-    }
-        
     if (-not (Test-Path -Path ("$basePath\apps\$releaseTypeFolder\$extensionID") -PathType Container)) {
         # if no extension found found, use the previous file structure, throw error if not found in that function
         return Get-AppTargetFilePathWithoutReleaseType -extensionID $extensionID -extensionVersion $extensionVersion
     }
 
+    if ([version]$latestExistingVersion -eq [version]'0.0.0.0') {
+        Write-Error "Cannot find any version for $extensionID."
+    }
     if ([version]$latestExistingVersion -lt [version]$extensionVersion) {
         Write-Error "Cannot find version $extensionVersion for $extensionID. Latest existing version is $latestExistingVersion."
     }
@@ -185,7 +195,7 @@ function Get-AppTargetFilePathWithoutReleaseType {
     [CmdletBinding()]
     Param (
         [string] $extensionID,
-        [string] $extensionVersion
+        [version] $extensionVersion = '0.0.0.0'
     )
     
     $settings = $ENV:AL_SETTINGS | ConvertFrom-Json
@@ -198,6 +208,9 @@ function Get-AppTargetFilePathWithoutReleaseType {
     }
 
     $latestExistingVersion = Get-LatestVersion -extensionID $extensionID -releaseType ''
+    if ([version]$latestExistingVersion -eq [version]'0.0.0.0') {
+        Write-Error "Cannot find any version for $extensionID."
+    }
     if ([version]$latestExistingVersion -lt [version]$extensionVersion) {
         Write-Error "Cannot find version $extensionVersion for $extensionID. Latest existing version is $latestExistingVersion."
     }

--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -151,7 +151,7 @@ function Get-ReleaseTypeFolderName {
         [switch] $isPreview
     )
 
-    $releaseTypeFolder = 'stable'
+    $releaseTypeFolder = 'public'
     if ($isPreview -eq $true) {
         $releaseTypeFolder = 'preview'
     }

--- a/ReadSettings/ReadSettings.Helper.ps1
+++ b/ReadSettings/ReadSettings.Helper.ps1
@@ -113,6 +113,7 @@ function ReadSettings {
         "nugetBCDevToolsVersion"          = "15.0.18.19684-beta"   
         "artifactUrlCacheKeepHours"       = 6
         "overrideResourceExposurePolicy"  = $false
+        "previousRelease"                 = ""
     }
 
     # Read settings from files and merge them into the settings object

--- a/RunPipeline/README.md
+++ b/RunPipeline/README.md
@@ -10,7 +10,7 @@ Run the Business Central app using BCCOntainerHelper Run-ALPipeline
 | buildMode | | Specifies a mode to use for the build step. Supported values are Default, Translated. Translated creates the translation file during the build. | Default |
 | installAppsJson | | A JSON-formatted list of apps to install | [] |
 | installTestAppsJson | | A JSON-formatted list of test apps to install | [] |
-| skipAppsInPreview | | If specified, build will use only stable/public releases as dependencies. This value is used only when the artifact has not been determined in previous steps or when determined artifact is different from the one provided as the parameter. | [] |
+| skipAppsInPreview | | If specified, build will use only public releases as dependencies. This value is used only when the artifact has not been determined in previous steps or when determined artifact is different from the one provided as the parameter. | [] |
 
 ## ENV INPUT variables
 

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -119,9 +119,6 @@ try {
         }
     }
 
-    Write-Host "Previous version $($settings.previousRelease)"
-    Write-Error "DEBUG STOP"
-
     $additionalCountries = $settings.additionalCountries
 
     $imageName = $settings.cacheImageName

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -119,6 +119,9 @@ try {
         }
     }
 
+    Write-Host "Previous version $($settings.previousRelease)"
+    Write-Error "DEBUG STOP"
+
     $additionalCountries = $settings.additionalCountries
 
     $imageName = $settings.cacheImageName

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -110,9 +110,13 @@ try {
 
     $previousApps = @()
     if (!$settings.skipUpgrade) {
-        Write-Host "::group::Locating previous release"
-        Write-Host "Skipping upgrade validation - NOT YET IMPLEMENTED" # TODO Implement upgrade validation
-        Write-Host "::endgroup::"
+        if ($settings.previousRelease) {
+            Write-Host "Using $($settings.previousRelease) as previous release"
+            $previousApps = $settings.previousRelease
+        }
+        else {
+            OutputWarning -message "No previous release found"
+        }
     }
 
     $additionalCountries = $settings.additionalCountries

--- a/StoreAppLocally/README.md
+++ b/StoreAppLocally/README.md
@@ -6,7 +6,7 @@ Allows to store the generated app file in local (or shared) folder for usage in 
 
 | Name                  | Required  | Description                                                       | Default value |
 | :--                   | :-:       | :--                                                               | :--           |
-| isPreview             | No        | Specifies whether the app to store is preview or stable release   | No            |
+| isPreview             | No        | Specifies whether the app to store is preview or public release   | No            |
 
 ## ENV INPUT variables
 


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality of the repository analysis and dependency management scripts. The most important changes include adding functionality to locate the previous release, updating the handling of app dependencies, and modifying the terminology for release types.

Enhancements to repository analysis:

* [`.Internal/AnalyzeRepository.Helper.ps1`](diffhunk://#diff-95168f8bbef30e64eed2c0930da52890fbecf4a86ad631d7c24c8e41bbf3acb8R152-R175): Added logic to locate the previous release if the `skipUpgrade` setting is not enabled. This includes handling errors and providing appropriate messages.

Updates to dependency management:

* [`.Internal/FindDependencies.Helper.ps1`](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248L31-R51): Added the `Get-LatestRelease` function to retrieve the latest release file path for a given app ID.
* [`.Internal/FindDependencies.Helper.ps1`](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248R105-R154): Modified the `Get-AppTargetFilePath` function to improve the handling of version folders and provide better error messages when versions are not found. [[1]](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248R105-R154) [[2]](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248L188-R204) [[3]](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248R217-R219)

Terminology updates:

* `RunPipeline/README.md` and `StoreAppLocally/README.md`: Changed the term "stable release" to "public release" for consistency across documentation. [[1]](diffhunk://#diff-a13e0c20eaedf2b16f9ba31ac601f1b674b3c7814760c1f8fb34e9b0c7d8c305L13-R13) [[2]](diffhunk://#diff-cbdc3a4cf3c8cde841b46e9b3865c74d806d1df595189be971ca57b824a7b0e8L9-R9)

Additional settings:

* [`ReadSettings/ReadSettings.Helper.ps1`](diffhunk://#diff-f68e0b52fd2750401b799b2cf2698a2d3795379fce9ea2ac077e2e6aaf912b06R116): Added the `previousRelease` setting to store the previous release information.