### PR TITLE
Release 0.01.05 alfa 5

### DIFF
--- a/.Internal/AnalyzeRepository.Helper.ps1
+++ b/.Internal/AnalyzeRepository.Helper.ps1
@@ -149,6 +149,30 @@ function AnalyzeRepo {
                             $settings.appDependencies += Get-DependenciesAsTextString -dependencies $foundAppDependencies
                         }
                         Write-Host "Adding newly found APP dependencies: $($settings.appDependencies)"
+
+                        if (!$settings.skipUpgrade) {
+                            Write-Host "Locating previous release"      
+                            try {
+                                $latestRelease = Get-LatestRelease -appId $mainAppId 
+                                if ($latestRelease) {
+                                    Write-Host "Using $latestRelease as previous release"
+                                    $settings.previousRelease += $latestRelease
+                                }
+                                else {
+                                    OutputWarning -message "No previous release found"
+                                }
+                            }
+                            catch {
+                                Write-Host $_.Exception -ForegroundColor Red
+                                Write-Host $_.ScriptStackTrace
+                                Write-Host $_.PSMessageDetails
+    
+                                Write-Error "Error trying to locate previous release. See previous lines for details."
+                            }
+                        }
+                        else {
+                            Write-Host "Skipping upgrade check"
+                        }
                     }
                     elseif ($testFolder) {
                         $foundTestDependencies = @(Get-AppDependencies -appJsonFilePath $appJsonFile -excludeExtensionID $mainAppId -minBcVersion $minBcVersion @allBCDependenciesParam)

--- a/ReadSettings/ReadSettings.Helper.ps1
+++ b/ReadSettings/ReadSettings.Helper.ps1
@@ -113,6 +113,7 @@ function ReadSettings {
         "nugetBCDevToolsVersion"          = "15.0.18.19684-beta"   
         "artifactUrlCacheKeepHours"       = 6
         "overrideResourceExposurePolicy"  = $false
+        "previousRelease"                 = ""
     }
 
     # Read settings from files and merge them into the settings object

--- a/RunPipeline/README.md
+++ b/RunPipeline/README.md
@@ -10,7 +10,7 @@ Run the Business Central app using BCCOntainerHelper Run-ALPipeline
 | buildMode | | Specifies a mode to use for the build step. Supported values are Default, Translated. Translated creates the translation file during the build. | Default |
 | installAppsJson | | A JSON-formatted list of apps to install | [] |
 | installTestAppsJson | | A JSON-formatted list of test apps to install | [] |
-| skipAppsInPreview | | If specified, build will use only stable/public releases as dependencies. This value is used only when the artifact has not been determined in previous steps or when determined artifact is different from the one provided as the parameter. | [] |
+| skipAppsInPreview | | If specified, build will use only public releases as dependencies. This value is used only when the artifact has not been determined in previous steps or when determined artifact is different from the one provided as the parameter. | [] |
 
 ## ENV INPUT variables
 

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -110,9 +110,13 @@ try {
 
     $previousApps = @()
     if (!$settings.skipUpgrade) {
-        Write-Host "::group::Locating previous release"
-        Write-Host "Skipping upgrade validation - NOT YET IMPLEMENTED" # TODO Implement upgrade validation
-        Write-Host "::endgroup::"
+        if ($settings.previousRelease) {
+            Write-Host "Using $($settings.previousRelease) as previous release"
+            $previousApps = $settings.previousRelease
+        }
+        else {
+            OutputWarning -message "No previous release found"
+        }
     }
 
     $additionalCountries = $settings.additionalCountries

--- a/StoreAppLocally/README.md
+++ b/StoreAppLocally/README.md
@@ -6,7 +6,7 @@ Allows to store the generated app file in local (or shared) folder for usage in 
 
 | Name                  | Required  | Description                                                       | Default value |
 | :--                   | :-:       | :--                                                               | :--           |
-| isPreview             | No        | Specifies whether the app to store is preview or stable release   | No            |
+| isPreview             | No        | Specifies whether the app to store is preview or public release   | No            |
 
 ## ENV INPUT variables
 


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality of the repository analysis and dependency management scripts. The most important changes include adding a new function to get the latest release, modifying existing functions to handle version and release type parameters more effectively, and updating documentation to reflect these changes.

Enhancements to repository analysis:

* [`.Internal/AnalyzeRepository.Helper.ps1`](diffhunk://#diff-95168f8bbef30e64eed2c0930da52890fbecf4a86ad631d7c24c8e41bbf3acb8R152-R175): Added logic to locate the previous release and handle errors during this process.

Improvements to dependency management:

* [`.Internal/FindDependencies.Helper.ps1`](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248L31-R51): Added the `Get-LatestRelease` function to retrieve the latest release for a given app ID.
* [`.Internal/FindDependencies.Helper.ps1`](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248R105-R154): Modified `Get-AppTargetFilePath` to handle version and release type parameters more effectively and added error handling for missing versions.
* [`.Internal/FindDependencies.Helper.ps1`](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248L188-R204): Updated `Get-AppTargetFilePathWithoutReleaseType` to include default version and error handling for missing versions. [[1]](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248L188-R204) [[2]](diffhunk://#diff-007f1c7db4bbe41ca44ab8331d4f89414a0ed4547fc7290273a093d0e721d248R217-R219)

Documentation updates:

* [`RunPipeline/README.md`](diffhunk://#diff-a13e0c20eaedf2b16f9ba31ac601f1b674b3c7814760c1f8fb34e9b0c7d8c305L13-R13): Updated the description of the `skipAppsInPreview` parameter to reflect that it now uses only public releases as dependencies.
* [`StoreAppLocally/README.md`](diffhunk://#diff-cbdc3a4cf3c8cde841b46e9b3865c74d806d1df595189be971ca57b824a7b0e8L9-R9): Updated the description of the `isPreview` parameter to specify that it distinguishes between preview and public releases.