### PR TITLE
Ignore Excluded Packages

### DIFF
--- a/DetermineNugetPackages/DetermineNugetPackages.ps1
+++ b/DetermineNugetPackages/DetermineNugetPackages.ps1
@@ -27,11 +27,11 @@ try {
     $dependenciesPackageCachePath = "$baseRepoFolder\.dependencyPackages"
     mkdir $dependenciesPackageCachePath
     
-    nuget install $applicationPackage -outputDirectory $buildCacheFolder 
-    foreach ($Dependency in $manifestObject.dependencies) {
-        $PackageName = Get-BCDevOpsFlowsNuGetPackageId -id $Dependency.id -name $Dependency.name -publisher $Dependency.publisher
-        Write-Host "Get $PackageName"
-        nuget install $PackageName -outputDirectory $dependenciesPackageCachePath
+    Write-Host "Getting application package $applicationPackage"
+    Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $applicationPackage -folder $buildCacheFolder -allowPrerelease:$true | Out-Null
+    foreach ($dependency in $manifestObject.dependencies) {
+        Write-Host "Getting $($dependency.name) using name $($dependency.id)"
+        Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $dependency.id -folder $dependenciesPackageCachePath -allowPrerelease:$true | Out-Null
     }
 }
 catch {


### PR DESCRIPTION
This pull request includes changes to the `DetermineNugetPackages.ps1` script to improve how NuGet packages are handled and retrieved. The most important changes include replacing the `nuget install` commands with a custom function and adding more descriptive logging.

Improvements to NuGet package handling:

* [`DetermineNugetPackages/DetermineNugetPackages.ps1`](diffhunk://#diff-59649d901cd0690a8b0fdb74c02af286c4640cfb37ed7d9b4988c379739b25e4L30-R34): Replaced `nuget install` commands with `Get-BCDevOpsFlowsNuGetPackageToFolder` to handle package retrieval, allowing for pre-release packages.

Enhancements to logging:

* [`DetermineNugetPackages/DetermineNugetPackages.ps1`](diffhunk://#diff-59649d901cd0690a8b0fdb74c02af286c4640cfb37ed7d9b4988c379739b25e4L30-R34): Added descriptive logging for retrieving application and dependency packages.