### PR TITLE
Ignore Excluded Packages + NuGet package lookup improvements

### DIFF
--- a/.Internal/NuGet/Find-BCDevOpsFlowsNuGetPackage.ps1
+++ b/.Internal/NuGet/Find-BCDevOpsFlowsNuGetPackage.ps1
@@ -7,12 +7,8 @@
   Find Business Central NuGet Package from NuGet Server
  .OUTPUTS
   BcDevOpsFlowsNuGetFeed class, packageId and package Version
- .PARAMETER nuGetServerUrl
-  NuGet Server URL
-  Default: https://api.nuget.org/v3/index.json
- .PARAMETER nuGetToken
-  NuGet Token for authenticated access to the NuGet Server
-  If not specified, the NuGet Server is accessed anonymously (and needs to support this)
+ .PARAMETER trustedNugetFeeds
+  Array of objects with nuget feeds to trust in the format @([PSCustomObject]@{Url="https://api.nuget.org/v3/index.json"; Token=""; Patterns=@('*'); Fingerprints=@()})
  .PARAMETER packageName
   Package Name to search for.
   This can be the full name or a partial name with wildcards.
@@ -33,14 +29,12 @@
  .EXAMPLE
   $feed, $packageId, $packageVersion = Find-BCDevOpsFlowsNuGetPackage -packageName 'FreddyKristiansen.BingMapsPTE.165d73c1-39a4-4fb6-85a5-925edc1684fb'
  .EXAMPLE
-  $feed, $packageId, $packageVersion = Find-BCDevOpsFlowsNuGetPackage -nuGetServerUrl $nugetServerUrl -nuGetToken $nuGetToken -packageName '437dbf0e-84ff-417a-965d-ed2bb9650972' -allowPrerelease
+  $feed, $packageId, $packageVersion = Find-BCDevOpsFlowsNuGetPackage -trustedNugetFeeds $trustedNugetFeeds -nuGetToken $nuGetToken -packageName '437dbf0e-84ff-417a-965d-ed2bb9650972' -allowPrerelease
 #>
 Function Find-BCDevOpsFlowsNuGetPackage {
     Param(
         [Parameter(Mandatory = $false)]
-        [string] $nuGetServerUrl = "",
-        [Parameter(Mandatory = $false)]
-        [string] $nuGetToken = "",
+        [string] $trustedNugetFeeds = @([PSCustomObject]@{"Url" = "https://api.nuget.org/v3/index.json"; "Token" = ""; "Patterns" = @('*'); "Fingerprints" = @() }),
         [Parameter(Mandatory = $true)]
         [string] $packageName,
         [Parameter(Mandatory = $false)]
@@ -55,7 +49,7 @@ Function Find-BCDevOpsFlowsNuGetPackage {
 
     $bestmatch = $null
     # Search all trusted feeds for the package
-    foreach ($feed in (@([PSCustomObject]@{ "Url" = $nuGetServerUrl; "Token" = $nuGetToken; "Patterns" = @('*'); "Fingerprints" = @() }) + $bcContainerHelperConfig.TrustedNuGetFeeds)) {
+    foreach ($feed in ($trustedNugetFeeds + $bcContainerHelperConfig.TrustedNuGetFeeds)) {
         if ($feed -and $feed.Url) {
             Write-Host "Search NuGetFeed $($feed.Url)"
             if (!($feed.PSObject.Properties.Name -eq 'Token')) { $feed | Add-Member -MemberType NoteProperty -Name 'Token' -Value '' }

--- a/.Internal/NuGet/Find-BCDevOpsFlowsNuGetPackage.ps1
+++ b/.Internal/NuGet/Find-BCDevOpsFlowsNuGetPackage.ps1
@@ -34,7 +34,7 @@
 Function Find-BCDevOpsFlowsNuGetPackage {
     Param(
         [Parameter(Mandatory = $false)]
-        [string] $trustedNugetFeeds = @([PSCustomObject]@{"Url" = "https://api.nuget.org/v3/index.json"; "Token" = ""; "Patterns" = @('*'); "Fingerprints" = @() }),
+        $trustedNugetFeeds = @([PSCustomObject]@{"Url" = "https://api.nuget.org/v3/index.json"; "Token" = ""; "Patterns" = @('*'); "Fingerprints" = @() }),
         [Parameter(Mandatory = $true)]
         [string] $packageName,
         [Parameter(Mandatory = $false)]

--- a/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
+++ b/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
@@ -46,7 +46,7 @@
 Function Get-BCDevOpsFlowsNuGetPackageToFolder {
     Param(
         [Parameter(Mandatory = $false)]
-        [string] $trustedNugetFeeds = @([PSCustomObject]@{"Url" = "https://api.nuget.org/v3/index.json"; "Token" = ""; "Patterns" = @('*'); "Fingerprints" = @() }),
+        $trustedNugetFeeds = @([PSCustomObject]@{"Url" = "https://api.nuget.org/v3/index.json"; "Token" = ""; "Patterns" = @('*'); "Fingerprints" = @() }),
         [Parameter(Mandatory = $false)]
         [string] $nuGetToken = "",
         [Parameter(Mandatory = $true)]

--- a/.Internal/NuGet/Publish-BCDevOpsFlowsNuGetPackageToContainer.ps1
+++ b/.Internal/NuGet/Publish-BCDevOpsFlowsNuGetPackageToContainer.ps1
@@ -88,7 +88,13 @@ Function Publish-BCDevOpsFlowsNuGetPackageToContainer {
         else {
             Write-Host "Prereleased packages are not allowed"
         }
-        if (Get-BCDevOpsFlowsNuGetPackageToFolder -nuGetServerUrl $nuGetServerUrl -nuGetToken $nuGetToken -packageName $packageName -version $version -appSymbolsFolder $tmpFolder -installedApps $installedApps -installedPlatform $installedPlatform -installedCountry $installedCountry -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease ) {
+        $nuGetFeed = @(
+            [PSCustomObject]@{
+                "nuGetServerUrl"    = $nuGetServerUrl; 
+                "nuGetToken"        = $nuGetToken; 
+            }
+        )
+        if (Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $nuGetFeed -packageName $packageName -version $version -appSymbolsFolder $tmpFolder -installedApps $installedApps -installedPlatform $installedPlatform -installedCountry $installedCountry -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease ) {
             $appFiles = Get-Item -Path (Join-Path $tmpFolder '*.app') | ForEach-Object {
                 if ($appSymbolsFolder) {
                     Copy-Item -Path $_.FullName -Destination $appSymbolsFolder -Force

--- a/DetermineNugetPackages/DetermineNugetPackages.ps1
+++ b/DetermineNugetPackages/DetermineNugetPackages.ps1
@@ -28,11 +28,11 @@ try {
     mkdir $dependenciesPackageCachePath
     
     Write-Host "Getting application package $applicationPackage"
-    Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $applicationPackage $buildCacheFolder -checkLocalVersion | Out-Null
+    Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $applicationPackage -appSymbolsFolder $buildCacheFolder -checkLocalVersion | Out-Null
     foreach ($dependency in $manifestObject.dependencies) {
         $packageName = Get-BCDevOpsFlowsNuGetPackageId -id $dependency.id -name $dependency.name -publisher $dependency.publisher
         Write-Host "Getting $($dependency.name) using name $($dependency.id)"
-        Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $packageName -folder $dependenciesPackageCachePath -allowPrerelease:$true | Out-Null
+        Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $packageName -appSymbolsFolder $dependenciesPackageCachePath -allowPrerelease:$true | Out-Null
     }
 }
 catch {

--- a/DetermineNugetPackages/DetermineNugetPackages.ps1
+++ b/DetermineNugetPackages/DetermineNugetPackages.ps1
@@ -27,11 +27,11 @@ try {
     $dependenciesPackageCachePath = "$baseRepoFolder\.dependencyPackages"
     mkdir $dependenciesPackageCachePath
     
-    nuget install $applicationPackage -outputDirectory $buildCacheFolder 
-    foreach ($Dependency in $manifestObject.dependencies) {
-        $PackageName = Get-BCDevOpsFlowsNuGetPackageId -id $Dependency.id -name $Dependency.name -publisher $Dependency.publisher
-        Write-Host "Get $PackageName"
-        nuget install $PackageName -outputDirectory $dependenciesPackageCachePath
+    Write-Host "Getting application package $applicationPackage"
+    Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $applicationPackage -folder $buildCacheFolder -allowPrerelease:$true | Out-Null
+    foreach ($dependency in $manifestObject.dependencies) {
+        Write-Host "Getting $($dependency.name) using name $($dependency.id)"
+        Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $dependency.id -folder $dependenciesPackageCachePath -allowPrerelease:$true | Out-Null
     }
 }
 catch {

--- a/DetermineNugetPackages/DetermineNugetPackages.ps1
+++ b/DetermineNugetPackages/DetermineNugetPackages.ps1
@@ -28,10 +28,11 @@ try {
     mkdir $dependenciesPackageCachePath
     
     Write-Host "Getting application package $applicationPackage"
-    Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $applicationPackage -folder $buildCacheFolder -allowPrerelease:$true | Out-Null
+    nuget install $applicationPackage -outputDirectory $buildCacheFolder 
     foreach ($dependency in $manifestObject.dependencies) {
+        $packageName = Get-BCDevOpsFlowsNuGetPackageId -id $dependency.id -name $dependency.name -publisher $dependency.publisher
         Write-Host "Getting $($dependency.name) using name $($dependency.id)"
-        Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $dependency.id -folder $dependenciesPackageCachePath -allowPrerelease:$true | Out-Null
+        Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $packageName -folder $dependenciesPackageCachePath -allowPrerelease:$true | Out-Null
     }
 }
 catch {

--- a/DetermineNugetPackages/DetermineNugetPackages.ps1
+++ b/DetermineNugetPackages/DetermineNugetPackages.ps1
@@ -30,11 +30,11 @@ try {
     $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL -trustMicrosoftNuGetFeeds $settings.trustMicrosoftNuGetFeeds
     
     Write-Host "Getting application package $applicationPackage"
-    Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -packageName $applicationPackage -appSymbolsFolder $buildCacheFolder -checkLocalVersion | Out-Null
+    Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -packageName $applicationPackage -appSymbolsFolder $buildCacheFolder -downloadDependencies 'all' | Out-Null
     foreach ($dependency in $manifestObject.dependencies) {
         $packageName = Get-BCDevOpsFlowsNuGetPackageId -id $dependency.id -name $dependency.name -publisher $dependency.publisher
         Write-Host "Getting $($dependency.name) using name $($dependency.id)"
-        Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -packageName $packageName -appSymbolsFolder $dependenciesPackageCachePath -allowPrerelease:$true | Out-Null
+        Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -packageName $packageName -appSymbolsFolder $dependenciesPackageCachePath -downloadDependencies 'allButMicrosoft' -allowPrerelease:$true | Out-Null
     }
 }
 catch {

--- a/DetermineNugetPackages/DetermineNugetPackages.ps1
+++ b/DetermineNugetPackages/DetermineNugetPackages.ps1
@@ -27,12 +27,14 @@ try {
     $dependenciesPackageCachePath = "$baseRepoFolder\.dependencyPackages"
     mkdir $dependenciesPackageCachePath
     
+    $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL -trustMicrosoftNuGetFeeds $settings.trustMicrosoftNuGetFeeds
+    
     Write-Host "Getting application package $applicationPackage"
-    Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $applicationPackage -appSymbolsFolder $buildCacheFolder -checkLocalVersion | Out-Null
+    Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -packageName $applicationPackage -appSymbolsFolder $buildCacheFolder -checkLocalVersion | Out-Null
     foreach ($dependency in $manifestObject.dependencies) {
         $packageName = Get-BCDevOpsFlowsNuGetPackageId -id $dependency.id -name $dependency.name -publisher $dependency.publisher
         Write-Host "Getting $($dependency.name) using name $($dependency.id)"
-        Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $packageName -appSymbolsFolder $dependenciesPackageCachePath -allowPrerelease:$true | Out-Null
+        Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -packageName $packageName -appSymbolsFolder $dependenciesPackageCachePath -allowPrerelease:$true | Out-Null
     }
 }
 catch {

--- a/DetermineNugetPackages/DetermineNugetPackages.ps1
+++ b/DetermineNugetPackages/DetermineNugetPackages.ps1
@@ -28,7 +28,7 @@ try {
     mkdir $dependenciesPackageCachePath
     
     Write-Host "Getting application package $applicationPackage"
-    nuget install $applicationPackage -outputDirectory $buildCacheFolder 
+    Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $applicationPackage $buildCacheFolder -checkLocalVersion | Out-Null
     foreach ($dependency in $manifestObject.dependencies) {
         $packageName = Get-BCDevOpsFlowsNuGetPackageId -id $dependency.id -name $dependency.name -publisher $dependency.publisher
         Write-Host "Getting $($dependency.name) using name $($dependency.id)"

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -234,12 +234,6 @@ try {
     }
 
     if (($bcContainerHelperConfig.ContainsKey('TrustedNuGetFeeds') -and ($bcContainerHelperConfig.TrustedNuGetFeeds.Count -gt 0)) -and ($runAlPipelineParams.Keys -notcontains 'InstallMissingDependencies')) {
-        if ($githubPackagesContext) {
-            $gitHubPackagesCredential = $gitHubPackagesContext | ConvertFrom-Json
-        }
-        else {
-            $gitHubPackagesCredential = [PSCustomObject]@{ "serverUrl" = ''; "token" = '' }
-        }
         $runAlPipelineParams += @{
             "InstallMissingDependencies" = {
                 Param([Hashtable]$parameters)
@@ -249,8 +243,6 @@ try {
                     $version = $appName.SubString($appName.LastIndexOf('_') + 1)
                     $version = [System.Version]$version.SubString(0, $version.Length - 4)
                     $publishParams = @{
-                        "nuGetServerUrl" = $gitHubPackagesCredential.serverUrl
-                        "nuGetToken"     = $gitHubPackagesCredential.token
                         "packageName"    = $appId
                         "version"        = $version
                     }


### PR DESCRIPTION
This pull request updates the PowerShell scripts to replace individual NuGet server URL and token parameters with a single parameter for trusted NuGet feeds. This change simplifies the handling of multiple NuGet feeds and improves code maintainability.

Key changes include:

### Parameter Updates:
* [`.Internal/NuGet/Find-BCDevOpsFlowsNuGetPackage.ps1`](diffhunk://#diff-76fea16a407b1575d17a9d49310934ff49bfd1d7fa5b233c68816d5023893fddL10-R11): Replaced `nuGetServerUrl` and `nuGetToken` parameters with `trustedNugetFeeds`, an array of objects representing trusted NuGet feeds. [[1]](diffhunk://#diff-76fea16a407b1575d17a9d49310934ff49bfd1d7fa5b233c68816d5023893fddL10-R11) [[2]](diffhunk://#diff-76fea16a407b1575d17a9d49310934ff49bfd1d7fa5b233c68816d5023893fddL36-R37)
* [`.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1`](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L6-R7): Updated to use `trustedNugetFeeds` parameter instead of `nuGetServerUrl` and `nuGetToken`. [[1]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L6-R7) [[2]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L53-R49) [[3]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L103-R104) [[4]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L140-R136) [[5]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L274-R270)

### Example and Function Adjustments:
* [`.Internal/NuGet/Publish-BCDevOpsFlowsNuGetPackageToContainer.ps1`](diffhunk://#diff-633feba1be358ad5f735b82698771f9292cbed375d0c5d39cb2141d6db456c2cL91-R97): Modified to use `trustedNugetFeeds` parameter for fetching NuGet packages.
* [`DetermineNugetPackages/DetermineNugetPackages.ps1`](diffhunk://#diff-59649d901cd0690a8b0fdb74c02af286c4640cfb37ed7d9b4988c379739b25e4R30-R37): Added `trustedNuGetFeeds` parameter to package fetching commands.
* [`RunPipeline/RunPipeline.ps1`](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cL237-L242): Removed handling of individual GitHub package credentials and adjusted parameters accordingly. [[1]](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cL237-L242) [[2]](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cL252-L253)