### PR TITLE
Update Get-BCDevOpsFlowsNuGetPackage to reflect latest changes

### DIFF
--- a/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackage.ps1
+++ b/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackage.ps1
@@ -9,12 +9,8 @@
   string
   Path to the a tmp folder where the package is downloaded
   This folder should be deleted after usage
- .PARAMETER nuGetServerUrl
-  NuGet Server URL
-  Default: https://api.nuget.org/v3/index.json
- .PARAMETER nuGetToken
-  NuGet Token for authenticated access to the NuGet Server
-  If not specified, the NuGet Server is accessed anonymously (and needs to support this)
+ .PARAMETER trustedNugetFeeds
+  Array of objects with nuget feeds to trust in the format @([PSCustomObject]@{Url="https://api.nuget.org/v3/index.json"; Token=""; Patterns=@('*'); Fingerprints=@()})
  .PARAMETER packageName
   Package Name to search for.
   This can be the full name or a partial name with wildcards.
@@ -35,15 +31,13 @@
  .EXAMPLE
   Get-BCDevOpsFlowsNuGetPackage -packageName 'FreddyKristiansen.BingMapsPTE.165d73c1-39a4-4fb6-85a5-925edc1684fb'
  .EXAMPLE
-  Get-BCDevOpsFlowsNuGetPackage -nuGetServerUrl $nugetServerUrl -nuGetToken $nuGetToken -packageName '437dbf0e-84ff-417a-965d-ed2bb9650972' -allowPrerelease
+  Get-BCDevOpsFlowsNuGetPackage -trustedNugetFeeds $trustedNugetFeeds -packageName '437dbf0e-84ff-417a-965d-ed2bb9650972' -allowPrerelease
 #>
 Function Get-BCDevOpsFlowsNuGetPackage {
     Param(
         [Parameter(Mandatory = $false)]
-        [string] $nuGetServerUrl = "",
+        $trustedNugetFeeds = @([PSCustomObject]@{"Url" = "https://api.nuget.org/v3/index.json"; "Token" = ""; "Patterns" = @('*'); "Fingerprints" = @() }),
         [Parameter(Mandatory = $false)]
-        [string] $nuGetToken = "",
-        [Parameter(Mandatory = $true)]
         [string] $packageName,
         [Parameter(Mandatory = $false)]
         [string] $version = '0.0.0.0',
@@ -56,7 +50,7 @@ Function Get-BCDevOpsFlowsNuGetPackage {
     )
 
     try {    
-        $feed, $packageId, $packageVersion = Find-BCDevOpsFlowsNugetPackage -nuGetServerUrl $nuGetServerUrl -nuGetToken $nuGetToken -packageName $packageName -version $version -excludeVersions $excludeVersions -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:($allowPrerelease.IsPresent)
+        $feed, $packageId, $packageVersion = Find-BCDevOpsFlowsNugetPackage -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -excludeVersions $excludeVersions -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:($allowPrerelease.IsPresent)
         if (-not $feed) {
             Write-Host "No package found matching package name $($packageName) Version $($version)"
             return ''


### PR DESCRIPTION
This pull request includes significant changes to the `Get-BCDevOpsFlowsNuGetPackage.ps1` script, focusing on improving how NuGet feeds are handled by replacing individual parameters for NuGet server URL and token with a single parameter for trusted NuGet feeds.

Key changes:

* Updated parameter handling:
  * Removed `nuGetServerUrl` and `nuGetToken` parameters.
  * Added `trustedNugetFeeds` parameter, which accepts an array of objects representing trusted NuGet feeds.

* Example updates:
  * Modified examples to use the new `trustedNugetFeeds` parameter instead of `nuGetServerUrl` and `nuGetToken`.

* Function implementation:
  * Replaced `nuGetServerUrl` and `nuGetToken` with `trustedNugetFeeds` in the function parameters.
  * Updated the call to `Find-BCDevOpsFlowsNugetPackage` to use the new `trustedNugetFeeds` parameter.