### PR TITLE
Load external setup

### DIFF
--- a/.Scenarios/SettingsOverview.md
+++ b/.Scenarios/SettingsOverview.md
@@ -6,6 +6,8 @@ This page explains the configuration parameters supported by BCDevOps Flows.
 
 Settings can be defined in Azure Devops variables or in various settings file. When running a workflow or a local script, the settings are applied by reading settings from Azure DevOps variables and one or more settings files. Last applied settings file wins. The following lists the order of locations to search for settings:
 
+1. You can use `External settings json file` that will be used for all projects and repositories. Azure DevOps does not have **Organization Setup** so this is the only option how to replicate Organization Setup from GitHub. The link can be http, https or path to a file that is accessible from all runners.
+
 1. `AL_PROJECTSETTINGS` is **Azure DevOps environment variable** for project setting
 
 1. `.azure-pipelines/BCDevOpsFlows.Settings.json` is the **repository settings file**. This settings file contains settings that are relevant for all projects in the repository.
@@ -21,7 +23,7 @@ Settings can be defined in Azure Devops variables or in various settings file. W
 The following setup is design to automate management of your pipelines.
 
 ### **IMPORTANT - not all setting files are allowed for this settings** 
-This setup can be placed only in **BCDevOpsFlows.Settings.json** or **\<pipelineName\>.settings.json** (both the pipeline itself or the SetupPipelines.settings.json). All other (Azure DevOps variable and user-specific) settings are ignored.
+This setup can be placed only in **External settings json file**, **BCDevOpsFlows.Settings.json** or **\<pipelineName\>.settings.json** (both the pipeline itself or the SetupPipelines.settings.json). All other (Azure DevOps variable and user-specific) settings are ignored.
 
 ### **IMPORTANT - run SetupPipelines pipeline to apply this settings** 
 This setup is not applied until you run the **SetupPipelines** pipeline. **SetupPipelines** pipeline must be created manually and must be run whenever any of the following settings is changed.
@@ -39,6 +41,7 @@ This setup is not applied until you run the **SetupPipelines** pipeline. **Setup
 | <a id="BCDevOpsFlowsVariableGroup"></a>BCDevOpsFlowsVariableGroup | Specifies name of the variable group in your Azure DevOps pipeline that hosts environment variables. Once pipelines are created for the first time, you must allow access to the Pool in Azure DevOps. |  |
 | <a id="workflowTrigger"></a>workflowTrigger | Specifies pipeline triggers. See documentation at Microsoft Learn to learn more about structure https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#ci-triggers. This settings is available for all pipelines except "PullRequest". | Set for CICD and PublishToProduction pipelines |
 | <a id="workflowSchedule"></a>workflowSchedule | Specifies schedule when the pipeline should be automatically run. See documentation at Microsoft Learn to learn more about structure https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers. This settings is available for all pipelines except "PullRequest". | Set for TestCurrent, TestNextMinor and TestNextMajor |
+| <a id="externalSettingsLink"></a>externalSettingsLink | Specifies link to json file that contains settings that should be used for all projects and repositories. This path could be http, https or path to a file that is accessible from all runners. While technically you changing this value does not require running **SetupPipelines** pipelines, as the file can contain any of the options above, it's highly recommended to run **SetupPipelines** after change. |  |
 
 #### Example of "workflowTrigger" (used as default for CICD pipeline)
 

--- a/.Scenarios/SettingsOverview.md
+++ b/.Scenarios/SettingsOverview.md
@@ -6,7 +6,7 @@ This page explains the configuration parameters supported by BCDevOps Flows.
 
 Settings can be defined in Azure Devops variables or in various settings file. When running a workflow or a local script, the settings are applied by reading settings from Azure DevOps variables and one or more settings files. Last applied settings file wins. The following lists the order of locations to search for settings:
 
-1. You can use `External settings json file` that will be used for all projects and repositories. Azure DevOps does not have **Organization Setup** so this is the only option how to replicate Organization Setup from GitHub. The link can be http, https or path to a file that is accessible from all runners.
+1. You can use `External settings json file` that will be used for all projects and repositories. Azure DevOps does not have **Organization Setup** so this is the only option how to replicate Organization Setup from GitHub. The link can be http or https.
 
 1. `AL_PROJECTSETTINGS` is **Azure DevOps environment variable** for project setting
 
@@ -41,7 +41,7 @@ This setup is not applied until you run the **SetupPipelines** pipeline. **Setup
 | <a id="BCDevOpsFlowsVariableGroup"></a>BCDevOpsFlowsVariableGroup | Specifies name of the variable group in your Azure DevOps pipeline that hosts environment variables. Once pipelines are created for the first time, you must allow access to the Pool in Azure DevOps. |  |
 | <a id="workflowTrigger"></a>workflowTrigger | Specifies pipeline triggers. See documentation at Microsoft Learn to learn more about structure https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#ci-triggers. This settings is available for all pipelines except "PullRequest". | Set for CICD and PublishToProduction pipelines |
 | <a id="workflowSchedule"></a>workflowSchedule | Specifies schedule when the pipeline should be automatically run. See documentation at Microsoft Learn to learn more about structure https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers. This settings is available for all pipelines except "PullRequest". | Set for TestCurrent, TestNextMinor and TestNextMajor |
-| <a id="externalSettingsLink"></a>externalSettingsLink | Specifies link to json file that contains settings that should be used for all projects and repositories. This path could be http, https or path to a file that is accessible from all runners. While technically you changing this value does not require running **SetupPipelines** pipelines, as the file can contain any of the options above, it's highly recommended to run **SetupPipelines** after change. |  |
+| <a id="externalSettingsLink"></a>externalSettingsLink | Specifies link to json file that contains settings that should be used for all projects and repositories. This path could be http or https. While technically you changing this value does not require running **SetupPipelines** pipelines, as the file can contain any of the options above, it's highly recommended to run **SetupPipelines** after change. |  |
 
 #### Example of "workflowTrigger" (used as default for CICD pipeline)
 

--- a/ReadSettings/ReadSettings.Helper.ps1
+++ b/ReadSettings/ReadSettings.Helper.ps1
@@ -134,6 +134,7 @@ function ReadSettings {
         $externalSettingsObject = $null
         if ($externalSettingLink.StartsWith("http")) {
             try {
+                OutputDebug "Applying settings from external (http/https) settings file $externalSettingLink"
                 $response = Invoke-WebRequest -Uri $externalSettingLink -UseBasicParsing
                 $externalSettingsObject = $response.Content | ConvertFrom-Json
             }
@@ -142,12 +143,14 @@ function ReadSettings {
             }
         }
         else {
+            OutputDebug "Applying settings from external (shared file) settings file $externalSettingLink"
             $externalSettingsObject = GetSettingsObject -Path $externalSettingLink
         }
         $settingsObjects += @($externalSettingsObject)
     }
     # Read settings from project settings variable (parameter)
     if ($projectSettings) {
+        OutputDebug "Applying settings from project settings variable $projectSettings"
         $projectSettingsObject = $projectSettings | ConvertFrom-Json
         $settingsObjects += @($projectSettingsObject)
     }
@@ -214,6 +217,7 @@ function ReadSettings {
     }
     
     if ($externalSettingLink -eq "" -and $settings.externalSettingsLink) {
+        Write-Host "Recreating settings object with external settings link $($settings.externalSettingsLink)"
         $settings = ReadSettings -baseFolder $baseFolder -repoName $repoName -buildMode $buildMode -pipelineName $pipelineName -setupPipelineName $setupPipelineName -userReqForEmail $userReqForEmail -branchName $branchName -projectSettings $projectSettings -externalSettingLink $settings.externalSettingsLink
         $settings
         return

--- a/ReadSettings/ReadSettings.Helper.ps1
+++ b/ReadSettings/ReadSettings.Helper.ps1
@@ -3,7 +3,7 @@
 
 # Read settings from the settings files
 # Settings are read from the following files:
-# - External settings json file                             = Link to external settings file (could be http, https or path to file accessible from all runners)
+# - External settings json file                             = Link to external settings file (could be http or https)
 # - BCDevOpsFlowsProjectSettings (Azure DevOps Variable)    = Project settings variable
 # - .azure-pipelines/BCDevOpsFlows.Settings.json            = Repository Settings file
 # - .azure-pipelines/<pipelineName>.settings.json           = Workflow settings file
@@ -131,22 +131,18 @@ function ReadSettings {
     $settingsObjects = @()
     # Read settings from external settings file (if specified)
     if ($externalSettingLink -ne "") {
-        $externalSettingsObject = $null
-        if ($externalSettingLink.StartsWith("http")) {
-            try {
-                OutputDebug "Applying settings from external (http/https) settings file $externalSettingLink"
-                $response = Invoke-WebRequest -Uri $externalSettingLink -UseBasicParsing
-                $externalSettingsObject = $response.Content | ConvertFrom-Json
-            }
-            catch {
-                Write-Warning "Error reading external settings from $externalSettingLink. Error was $($_.Exception.Message).`n$($_.ScriptStackTrace)"
-            }
+        if (-not $externalSettingLink.StartsWith("http")) {
+            throw "External settings link must start with http/https"
         }
-        else {
-            OutputDebug "Applying settings from external (shared file) settings file $externalSettingLink"
-            $externalSettingsObject = GetSettingsObject -Path $externalSettingLink
+        try {
+            OutputDebug "Applying settings from external (http/https) settings file $externalSettingLink"
+            $response = Invoke-WebRequest -Uri $externalSettingLink -UseBasicParsing
+            $externalSettingsObject = $response.Content | ConvertFrom-Json
+            $settingsObjects += @($externalSettingsObject)
         }
-        $settingsObjects += @($externalSettingsObject)
+        catch {
+            Write-Warning "Error reading external settings from $externalSettingLink. Error was $($_.Exception.Message).`n$($_.ScriptStackTrace)"
+        }
     }
     # Read settings from project settings variable (parameter)
     if ($projectSettings) {
@@ -155,20 +151,24 @@ function ReadSettings {
         $settingsObjects += @($projectSettingsObject)
     }
     # Read settings from repository settings file
+    OutputDebug "Applying settings from repository settings file $baseFolder/$RepoSettingsFile"
     $repoSettingsObject = GetSettingsObject -Path (Join-Path $baseFolder $RepoSettingsFile)
     $settingsObjects += @($repoSettingsObject)
     if ($setupPipelineName -ne "") {
         # Read settings from setup pipeline settings file
+        OutputDebug "Applying settings from setup pipeline settings file $baseFolder/$scriptsFolderName/$setupPipelineName.settings.json"
         $setupSettingsObject = GetSettingsObject -Path (Join-Path $baseFolder "$scriptsFolderName/$setupPipelineName.settings.json")
         $settingsObjects += @($setupSettingsObject)
     }
     if ($pipelineName -ne "") {
         # Read settings from workflow settings file
+        OutputDebug "Applying settings from workflow settings file $baseFolder/$scriptsFolderName/$pipelineName.settings.json"
         $workflowSettingsObject = GetSettingsObject -Path (Join-Path $baseFolder "$scriptsFolderName/$pipelineName.settings.json")
         $settingsObjects += @($workflowSettingsObject)
     }
     if ($userReqForEmail -ne "") {
         # Read settings from user settings file
+        OutputDebug "Applying settings from user settings file $baseFolder/$scriptsFolderName/$userReqForEmail.settings.json"
         $userSettingsObject = GetSettingsObject -Path (Join-Path $baseFolder "$scriptsFolderName/$userReqForEmail.settings.json")
         $settingsObjects += @($userSettingsObject)
     }

--- a/SetupPipelines/SetupPipelines.ps1
+++ b/SetupPipelines/SetupPipelines.ps1
@@ -8,7 +8,7 @@ Param()
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\Common\Import-Common.ps1" -Resolve)
 
 try {
-    $settings = ReadSettings -pipelineName '' -setupPipelineName "$ENV:AL_PIPELINENAME" -userName '' -branchName '' | ConvertTo-HashTable -recurse
+    $settings = ReadSettings -pipelineName '' -setupPipelineName "$ENV:AL_PIPELINENAME" -userReqForEmail '' -branchName '' | ConvertTo-HashTable -recurse
     if ([string]::IsNullOrEmpty($settings.pipelineBranch)) {
         throw "settings.pipelineBranch is required but was not provided."
     }


### PR DESCRIPTION
This pull request introduces support for an external JSON settings file to centralize configuration across multiple projects and repositories. Key changes include updates to documentation, new parameters in the `ReadSettings` function, and logic to fetch and merge external settings.

### Documentation Updates:
* [`.Scenarios/SettingsOverview.md`](diffhunk://#diff-0a85dd5a72c18c3ad31949b08bf2a17e2756479675c6ad1dd9fe06fd2bef6035R9-R10): Added details about the new "External settings JSON file" option for project-wide settings, including its usage and priority in the settings hierarchy. Also updated the list of allowed settings files and added a description of the `externalSettingsLink` parameter. [[1]](diffhunk://#diff-0a85dd5a72c18c3ad31949b08bf2a17e2756479675c6ad1dd9fe06fd2bef6035R9-R10) [[2]](diffhunk://#diff-0a85dd5a72c18c3ad31949b08bf2a17e2756479675c6ad1dd9fe06fd2bef6035L24-R26) [[3]](diffhunk://#diff-0a85dd5a72c18c3ad31949b08bf2a17e2756479675c6ad1dd9fe06fd2bef6035R44)

### Code Enhancements:
* `ReadSettings/ReadSettings.Helper.ps1`:
  - Added a new `externalSettingLink` parameter to the `ReadSettings` function to specify the external settings file URL.
  - Implemented logic to fetch and parse the external settings file, validate its URL format, and merge its contents with other settings. Debug outputs and error handling were added for better traceability.
  - Enhanced the function to recreate the settings object if the external settings link is updated dynamically.

### Bug Fix:
* [`SetupPipelines/SetupPipelines.ps1`](diffhunk://#diff-bfd3dc115f896c596edf191e2644c36d477af22bd10ecf7cb54f46f3125471aaL11-R11): Corrected a parameter name from `-userName` to `-userReqForEmail` when calling the `ReadSettings` function.