### PR TITLE
Run pipeline does not respect skip preview apps

### DIFF
--- a/.Internal/AnalyzeRepository.Helper.ps1
+++ b/.Internal/AnalyzeRepository.Helper.ps1
@@ -7,8 +7,7 @@ function AnalyzeRepo {
     [CmdletBinding()]
     Param(
         [hashtable] $settings,
-        [switch] $skipAppsInPreview,
-        [version] $minBcVersion = [version]'0.0.0.0'
+        [switch] $allowPrerelease
     )
     $settings = $settings | Copy-HashTable
 
@@ -45,10 +44,16 @@ function AnalyzeRepo {
 
     $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL -trustMicrosoftNuGetFeeds $settings.trustMicrosoftNuGetFeeds
     Write-Host "Checking appDependenciesNuGet and testDependenciesNuGet"
+    $getDependencyNuGetPackageParams = @{}
+    if ($allowPrerelease) {
+        $getDependencyNuGetPackageParams += @{
+            "allowPrerelease" = $true
+        }
+    }
     if ($settings.appDependenciesNuGet) {
         $settings.appDependenciesNuGet | ForEach-Object {
             $packageName = $_
-            $appFile = Get-BCDevOpsFlowsNuGetPackage -trustedNugetFeeds $trustedNuGetFeeds -packageName $packageName
+            $appFile = Get-BCDevOpsFlowsNuGetPackage -trustedNugetFeeds $trustedNuGetFeeds -packageName $packageName @getDependencyNuGetPackageParams
             if ($appFile) {
                 if (!$settings.appDependencies) {
                     $settings.appDependencies = @()
@@ -62,7 +67,7 @@ function AnalyzeRepo {
     if ($settings.testDependenciesNuGet) {
         $settings.testDependenciesNuGet | ForEach-Object {
             $packageName = $_
-            $appFile = Get-BCDevOpsFlowsNuGetPackage -trustedNugetFeeds $trustedNuGetFeeds -packageName $packageName
+            $appFile = Get-BCDevOpsFlowsNuGetPackage -trustedNugetFeeds $trustedNuGetFeeds -packageName $packageName @getDependencyNuGetPackageParams
             if ($appFile) {
                 if (!$settings.testDependencies) {
                     $settings.testDependencies = @()
@@ -101,17 +106,7 @@ function AnalyzeRepo {
     Write-Host "Analyzing Test App Dependencies"
     if ($settings.testFolders) { $settings.installTestRunner = $true }
     if ($settings.bcptTestFolders) { $settings.installPerformanceToolkit = $true }
-    Write-Host "Settings installTestRunner = $($settings.installTestRunner), installPerformanceToolkit = $($settings.installPerformanceToolkit)"
 
-    $foundAppDependencies + $foundTestDependencies | ForEach-Object {
-        $dependency = $_
-        if ($testRunnerApps.Contains($dependency.id)) { $settings.installTestRunner = $true }
-        if ($testFrameworkApps.Contains($dependency.id)) { $settings.installTestFramework = $true }
-        if ($testLibrariesApps.Contains($dependency.id)) { $settings.installTestLibraries = $true }
-        if ($performanceToolkitApps.Contains($dependency.id)) { $settings.installPerformanceToolkit = $true }
-    }
-    Write-Host "Settings installTestRunner = $($settings.installTestRunner), installTestFramework = $($settings.installTestFramework), installTestLibraries = $($settings.installTestLibraries), installPerformanceToolkit = $($settings.installPerformanceToolkit)"
-    
     Write-Host "App.json version $($settings.appJsonVersion)"
     Write-Host "Application Dependency $($settings.applicationDependency)"
 
@@ -147,14 +142,4 @@ function AnalyzeRepo {
     Write-Host "Analyzing repository completed"
     $settings | Add-Member -NotePropertyName analyzeRepoCompleted -NotePropertyValue $true -Force
     return $settings
-}
-
-function Get-DependenciesAsTextString {
-    [CmdletBinding()]
-    Param(
-        [array] $dependencies
-    )
-    return ($dependencies | ForEach-Object {
-            $_.appFile
-        }) -join ","
 }

--- a/DetermineArtifactUrl/DetermineArtifactUrl.ps1
+++ b/DetermineArtifactUrl/DetermineArtifactUrl.ps1
@@ -1,4 +1,7 @@
-Param()
+Param(
+    [Parameter(HelpMessage = "Specifies whether to include preview apps as dependencies.", Mandatory = $false)]
+    [switch] $skipAppsInPreview
+)
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\BCContainerHelper.Helper.ps1" -Resolve)
 
@@ -11,7 +14,14 @@ try {
     . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\WriteOutput.Helper.ps1" -Resolve)
 
     $settings = $ENV:AL_SETTINGS | ConvertFrom-Json | ConvertTo-HashTable
-    $settings = AnalyzeRepo -settings $settings
+
+    $analyzeRepoParams = @{}
+    if ($skipAppsInPreview) {
+        $analyzeRepoParams += @{
+            "allowPrerelease" = $true
+        }
+    }
+    $settings = AnalyzeRepo -settings $settings @analyzeRepoParams
     $artifactUrl = DetermineArtifactUrl -settings $settings
 
     # Set output variables

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -231,6 +231,7 @@ try {
     }
 
     # Initialize trusted NuGet feeds
+    $allowPrerelease = -not $skipAppsInPreview
     $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL -trustMicrosoftNuGetFeeds $settings.trustMicrosoftNuGetFeeds -skipSymbolsFeeds
     if (($trustedNuGetFeeds.Count -gt 0) -and ($runAlPipelineParams.Keys -notcontains 'InstallMissingDependencies')) {
         $runAlPipelineParams += @{
@@ -251,10 +252,10 @@ try {
                         }
                     }
                     if ($parameters.ContainsKey('containerName')) {
-                        Publish-BCDevOpsFlowsNuGetPackageToContainer -trustedNugetFeeds $trustedNuGetFeeds  -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams -ErrorAction SilentlyContinue -allowPrerelease:$true
+                        Publish-BCDevOpsFlowsNuGetPackageToContainer -trustedNugetFeeds $trustedNuGetFeeds  -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams -ErrorAction SilentlyContinue -allowPrerelease $allowPrerelease
                     }
                     else {
-                        Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -folder $parameters.appSymbolsFolder -allowPrerelease:$true @publishParams | Out-Null
+                        Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -folder $parameters.appSymbolsFolder -allowPrerelease $allowPrerelease @publishParams | Out-Null
                     }
                 }
             }

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -7,7 +7,7 @@ Param(
     [string] $installAppsJson = '[]',
     [Parameter(HelpMessage = "A JSON-formatted list of test apps to install", Mandatory = $false)]
     [string] $installTestAppsJson = '[]',
-    [Parameter(HelpMessage = "Specifies whether the app is in preview only.", Mandatory = $false)]
+    [Parameter(HelpMessage = "Specifies whether to include preview apps as dependencies.", Mandatory = $false)]
     [switch] $skipAppsInPreview
 )
 
@@ -62,7 +62,7 @@ try {
         $analyzeRepoParams = @{}
         if ($skipAppsInPreview) {
             $analyzeRepoParams += @{
-                "skipAppsInPreview" = $true
+                "allowPrerelease" = $true
             }
         }
 
@@ -231,7 +231,6 @@ try {
     }
 
     # Initialize trusted NuGet feeds
-    $allowPrerelease = -not $skipAppsInPreview
     $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL -trustMicrosoftNuGetFeeds $settings.trustMicrosoftNuGetFeeds -skipSymbolsFeeds
     if (($trustedNuGetFeeds.Count -gt 0) -and ($runAlPipelineParams.Keys -notcontains 'InstallMissingDependencies')) {
         $runAlPipelineParams += @{
@@ -251,12 +250,17 @@ try {
                             "CopyInstalledAppsToFolder" = $parameters.CopyInstalledAppsToFolder
                         }
                     }
-                    OutputDebug -Message "GetNuGetPackage with allowPrerelease = $allowPrerelease"
+                    if (-not $skipAppsInPreview) {
+                        $publishParams += @{
+                            "allowPrerelease" = $true
+                        }
+                    }
+                    OutputDebug -Message "GetNuGetPackage with allowPrerelease = $(-not $skipAppsInPreview)"
                     if ($parameters.ContainsKey('containerName')) {
-                        Publish-BCDevOpsFlowsNuGetPackageToContainer -trustedNugetFeeds $trustedNuGetFeeds  -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams -ErrorAction SilentlyContinue -allowPrerelease $allowPrerelease
+                        Publish-BCDevOpsFlowsNuGetPackageToContainer -trustedNugetFeeds $trustedNuGetFeeds  -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder -ErrorAction SilentlyContinue @publishParams
                     }
                     else {
-                        Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -folder $parameters.appSymbolsFolder -allowPrerelease $allowPrerelease @publishParams | Out-Null
+                        Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNuGetFeeds -folder $parameters.appSymbolsFolder @publishParams | Out-Null
                     }
                 }
             }

--- a/RunPipeline/RunPipeline.ps1
+++ b/RunPipeline/RunPipeline.ps1
@@ -251,6 +251,7 @@ try {
                             "CopyInstalledAppsToFolder" = $parameters.CopyInstalledAppsToFolder
                         }
                     }
+                    OutputDebug -Message "GetNuGetPackage with allowPrerelease = $allowPrerelease"
                     if ($parameters.ContainsKey('containerName')) {
                         Publish-BCDevOpsFlowsNuGetPackageToContainer -trustedNugetFeeds $trustedNuGetFeeds  -containerName $parameters.containerName -tenant $parameters.tenant -skipVerification -appSymbolsFolder $parameters.appSymbolsFolder @publishParams -ErrorAction SilentlyContinue -allowPrerelease $allowPrerelease
                     }


### PR DESCRIPTION
This pull request refactors the handling of preview app dependencies across multiple scripts, replacing the `skipAppsInPreview` parameter with a more descriptive `allowPrerelease` parameter. It also removes unused code for dependency processing and simplifies logic where preview apps are involved.

### Parameter Refactoring and Behavior Change:
* Replaced the `skipAppsInPreview` parameter with `allowPrerelease` in `AnalyzeRepo`, `DetermineArtifactUrl.ps1`, and `RunPipeline.ps1` to clarify its purpose. Updated related logic to reflect this change. (`[[1]](diffhunk://#diff-95168f8bbef30e64eed2c0930da52890fbecf4a86ad631d7c24c8e41bbf3acb8L10-R10)`, `[[2]](diffhunk://#diff-29fb9d01865cd8dd392d13e0a77a4af6e17a2afa393b58a082b6b476ae47379aL1-R4)`, `[[3]](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cL10-R10)`)

### Dependency Handling Improvements:
* Added conditional logic to pass the `allowPrerelease` flag when fetching NuGet packages for app and test dependencies in `AnalyzeRepo`. (`[[1]](diffhunk://#diff-95168f8bbef30e64eed2c0930da52890fbecf4a86ad631d7c24c8e41bbf3acb8R47-R56)`, `[[2]](diffhunk://#diff-95168f8bbef30e64eed2c0930da52890fbecf4a86ad631d7c24c8e41bbf3acb8L65-R70)`)
* Updated `RunPipeline.ps1` to ensure that `allowPrerelease` is included in the parameters for publishing and retrieving NuGet packages when applicable. (`[[1]](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cL65-R65)`, `[[2]](diffhunk://#diff-6c32d113f7ac0d63e4a508937dcf7410026f08c2a05d52b73e925a3c8160669cR253-R263)`)

### Code Simplification:
* Removed unused code related to analyzing test app dependencies, including redundant settings updates and debug messages in `AnalyzeRepo`. (`[.Internal/AnalyzeRepository.Helper.ps1L104-L113](diffhunk://#diff-95168f8bbef30e64eed2c0930da52890fbecf4a86ad631d7c24c8e41bbf3acb8L104-L113)`)
* Deleted the `Get-DependenciesAsTextString` function from `AnalyzeRepo` as it was no longer used. (`[.Internal/AnalyzeRepository.Helper.ps1L151-L160](diffhunk://#diff-95168f8bbef30e64eed2c0930da52890fbecf4a86ad631d7c24c8e41bbf3acb8L151-L160)`)