### PR TITLE
Use updateVersionNumber from setting when specified

### DIFF
--- a/.Scenarios/SettingsOverview.md
+++ b/.Scenarios/SettingsOverview.md
@@ -42,7 +42,9 @@ This setup is not applied until you run the **SetupPipelines** pipeline. **Setup
 | <a id="BCDevOpsFlowsVariableGroup"></a>BCDevOpsFlowsVariableGroup | Specifies name of the variable group in your Azure DevOps pipeline that hosts environment variables. Once pipelines are created for the first time, you must allow access to the Pool in Azure DevOps. |  |
 | <a id="workflowTrigger"></a>workflowTrigger | Specifies pipeline triggers. See documentation at Microsoft Learn to learn more about structure https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#ci-triggers. This settings is available for all pipelines except "PullRequest". | Set for CICD and PublishToProduction pipelines |
 | <a id="workflowSchedule"></a>workflowSchedule | Specifies schedule when the pipeline should be automatically run. See documentation at Microsoft Learn to learn more about structure https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers. This settings is available for all pipelines except "PullRequest". | Set for TestCurrent, TestNextMinor and TestNextMajor |
+| <a id="updateVersionNumber"></a>updateVersionNumber | Specifies the version (relative or absolute) to what the app version should be updated to. This setting is applied only to CICD and PublishToProduction pipelines. You can use both relative (+1, +0.1, ...) or absolute (1, 23.5, ...) notations. You must use only values allowed by the versionStrategy. If the version strategy calculates automatically last two digits, you cannot specify version that includes the third digit etc. |  |
 | <a id="externalSettingsLink"></a>externalSettingsLink | Specifies link to json file that contains settings that should be used for all projects and repositories. This path could be http or https. While technically changing this value does not require running the **SetupPipelines** pipeline, it is highly recommended to do so, as the file can contain any of the options above. |  |
+
 #### Example of "workflowTrigger" (used as default for CICD pipeline)
 
 ```json
@@ -173,7 +175,7 @@ Example, adding this:
     ]
 ```
 
-to your [project settings file](#where-are-the-settings-located) will ensure that all branches matching the patterns in branches will use doNotPublishApps=true and doNotSignApps=true during CI/CD. Conditions can be:
+to your [repository settings file](#where-are-the-settings-located) will ensure that all branches matching the patterns in branches will use doNotPublishApps=true and doNotSignApps=true during CI/CD. Conditions can be:
 
 - **repositories** settings will be applied to repositories matching the patterns
 - **buildModes** settings will be applied when building with these buildModes

--- a/IncrementVersion/IncrementVersion.ps1
+++ b/IncrementVersion/IncrementVersion.ps1
@@ -16,10 +16,12 @@ try {
 
     if ([string]::IsNullOrEmpty($versionNumber)) {
         if (-not (Get-Member -InputObject $settings -Name 'updateVersionNumber')) {
-            throw "Version number is not specified and settings.updateVersionNumber is not defined"
+            Write-Output "Version change not specified. Skipping version update."
+            exit 0
         }
         if ($settings.updateVersionNumber -eq '') {
-            throw "Version number is not specified and settings.updateVersionNumber is empty"
+            Write-Output "Version change not specified. Skipping version update."
+            exit 0
         }
         $versionNumber = $settings.updateVersionNumber
     }

--- a/IncrementVersion/IncrementVersion.ps1
+++ b/IncrementVersion/IncrementVersion.ps1
@@ -1,5 +1,5 @@
 Param(
-    [Parameter(HelpMessage = "The version to update to. Use Major.Minor[.Build][.Revision] for absolute change, use +1 to bump to the next major version, use +0.1 to bump to the next minor version, +0.0.1 to bump to the next build version or +0.0.0.1 to bump to the next revision version", Mandatory = $true)]
+    [Parameter(HelpMessage = "The version to update to. Use Major.Minor[.Build][.Revision] for absolute change, use +1 to bump to the next major version, use +0.1 to bump to the next minor version, +0.0.1 to bump to the next build version or +0.0.0.1 to bump to the next revision version", Mandatory = $false)]
     [string] $versionNumber
 )
 
@@ -13,6 +13,17 @@ Param(
 try {
     $baseFolder = $ENV:BUILD_REPOSITORY_LOCALPATH
     $settings = $ENV:AL_SETTINGS | ConvertFrom-Json
+
+    if ([string]::IsNullOrEmpty($versionNumber)) {
+        if (-not (Get-Member -InputObject $settings -Name 'updateVersionNumber')) {
+            throw "Version number is not specified and settings.updateVersionNumber is not defined"
+        }
+        if ($settings.updateVersionNumber -eq '') {
+            throw "Version number is not specified and settings.updateVersionNumber is empty"
+        }
+        $versionNumber = $settings.updateVersionNumber
+    }
+
     if ($versionNumber.StartsWith('+')) {
         # Handle incremental version number
         $allowedIncrementalVersionNumbers = @('+1', '+0.1')


### PR DESCRIPTION
This pull request introduces enhancements to version management in pipelines and updates documentation for clarity. The key changes include adding a new `updateVersionNumber` setting, modifying the `IncrementVersion.ps1` script to handle default versioning logic, and refining documentation for better usability.

### Documentation Updates:

* [`.Scenarios/SettingsOverview.md`](diffhunk://#diff-0a85dd5a72c18c3ad31949b08bf2a17e2756479675c6ad1dd9fe06fd2bef6035R45-R47): Added a new `updateVersionNumber` setting to specify the version to which the app should be updated. This setting supports both relative (e.g., `+1`, `+0.1`) and absolute (e.g., `1`, `23.5`) notations, with constraints based on the `versionStrategy`.
* [`.Scenarios/SettingsOverview.md`](diffhunk://#diff-0a85dd5a72c18c3ad31949b08bf2a17e2756479675c6ad1dd9fe06fd2bef6035L176-R178): Corrected a reference from "project settings file" to "repository settings file" for better accuracy.

### Script Enhancements:

* [`IncrementVersion/IncrementVersion.ps1`](diffhunk://#diff-5952a452a4726251380753d176fd762096ee29ec6c429191ae58269cef8572c3L2-R2): Made the `versionNumber` parameter optional and added logic to retrieve the default version from the `updateVersionNumber` setting if the parameter is not provided. This ensures a fallback mechanism and prevents errors when the version is not explicitly specified. [[1]](diffhunk://#diff-5952a452a4726251380753d176fd762096ee29ec6c429191ae58269cef8572c3L2-R2) [[2]](diffhunk://#diff-5952a452a4726251380753d176fd762096ee29ec6c429191ae58269cef8572c3R16-R26)