### PR TITLE
Workflow schedule in global settings and do not recreate setuppipeline

### DIFF
--- a/SetupPipelines/SetupPipelines.Helper.ps1
+++ b/SetupPipelines/SetupPipelines.Helper.ps1
@@ -150,18 +150,11 @@ function Update-PipelineYMLFile {
         [string]$filePath
     )
     
-    # Read settings without workflow specific settings
-    $settings = ReadSettings -pipelineName '' -setupPipelineName '' -userReqForEmail '' -branchName '' | ConvertTo-HashTable -recurse
-
+    # Get Yaml content and workflow name
     $yamlContent = Get-AsYamlFromFile -FileName $filePath
     $workflowName = $yamlContent.jobs[0].variables.AL_PIPELINENAME
-    foreach ($key in @($workflowScheduleKey, $workflowTriggerKey)) {
-        if ($settings.Keys -contains $key -and ($settings."$key")) {
-            throw "The $key setting is not allowed in the global repository settings. Please use the workflow specific settings file or conditional settings."
-        }
-    }
 
-    # Re-read settings and this time include workflow specific settings + setup pipeline settings
+    # Read settings including workflow specific settings + setup pipeline settings
     $settings = ReadSettings -pipelineName $workflowName -setupPipelineName "$ENV:AL_PIPELINENAME" -userReqForEmail '' -branchName '' | ConvertTo-HashTable -recurse
 
     # Any workflow (except for the Pull_Request) can have concurrency and schedule defined

--- a/SetupPipelines/SetupPipelines.ps1
+++ b/SetupPipelines/SetupPipelines.ps1
@@ -37,7 +37,7 @@ try {
     Invoke-GitPush "HEAD:$($settings.pipelineBranch)"
 
     $pipelineDevOpsFolderPath = Get-PipelineDevOpsFolderPath -settings $settings
-    $yamlFiles = Get-ChildItem -Path $yamlPipelineFolder -Filter *.yml -File
+    $yamlFiles = Get-ChildItem -Path $yamlPipelineFolder -Filter *.yml -File | Where-Object { $_.Name -ne "SetupPipelines.yml" }
     OutputDebug "Preparing pipelines for project '$ENV:SYSTEM_TEAMPROJECT' in organization '$ENV:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'"
     foreach ($pipelineYamlFilePath in $yamlFiles) {
         $pipelineName = $pipelineYamlFilePath.BaseName

--- a/SetupPipelines/SetupPipelines.ps1
+++ b/SetupPipelines/SetupPipelines.ps1
@@ -37,7 +37,7 @@ try {
     Invoke-GitPush "HEAD:$($settings.pipelineBranch)"
 
     $pipelineDevOpsFolderPath = Get-PipelineDevOpsFolderPath -settings $settings
-    $yamlFiles = Get-ChildItem -Path $yamlPipelineFolder -Filter *.yml -File | Where-Object { $_.Name -ne "SetupPipelines.yml" }
+    $yamlFiles = Get-ChildItem -Path $yamlPipelineFolder -Filter *.yml -File | Where-Object { $_.Name.ToLower() -ne "setuppipelines.yml" }
     OutputDebug "Preparing pipelines for project '$ENV:SYSTEM_TEAMPROJECT' in organization '$ENV:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'"
     foreach ($pipelineYamlFilePath in $yamlFiles) {
         $pipelineName = $pipelineYamlFilePath.BaseName


### PR DESCRIPTION
This pull request includes updates to the `SetupPipelines` PowerShell scripts to improve the handling of YAML pipeline files and streamline settings management. The most important changes involve refining the logic for reading settings and excluding specific files during pipeline preparation.

### Improvements to settings management:

* [`SetupPipelines/SetupPipelines.Helper.ps1`](diffhunk://#diff-0fa1165ed5b2e1ae710ba55c0f16db435870f60f1d3dbf50d821fbeee7de81c7L153-R157): Removed the validation of global repository settings (`$workflowScheduleKey` and `$workflowTriggerKey`) and simplified the logic to directly read settings with workflow-specific configurations. This ensures better alignment with the intended pipeline workflow.

### Refinements to pipeline file handling:

* [`SetupPipelines/SetupPipelines.ps1`](diffhunk://#diff-bfd3dc115f896c596edf191e2644c36d477af22bd10ecf7cb54f46f3125471aaL40-R40): Updated the logic for retrieving YAML files to exclude `SetupPipelines.yml` from the list of pipeline files, preventing unnecessary processing of this configuration file.