### PR TITLE
Git Case Insensitive

### DIFF
--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -3,6 +3,7 @@
 function Set-GitUser {
     invoke-git config --global user.email "BCDevOpsFlows@dev.azure.com"
     invoke-git config --global user.name "BCDevOps Flows Pipeline"
+    invoke-git config --global core.ignoreCase true
 }
 function Invoke-RestoreUnstagedChanges {
     Param(


### PR DESCRIPTION
This pull request makes a minor update to the `.Internal/GitHelper.Helper.ps1` script to configure Git to ignore case sensitivity in file names globally.

* [`.Internal/GitHelper.Helper.ps1`](diffhunk://#diff-05354af9e44fc7c2e8f783b7cfbb98c64a76f686c7c60db58b0bd003c0d8b548R6): Added a line to set the Git configuration `core.ignoreCase` to `true` in the `Set-GitUser` function.