### PR TITLE
Load appfolder name from settings

### DIFF
--- a/.Internal/ApplyAppJsonUpdates.Helper.ps1
+++ b/.Internal/ApplyAppJsonUpdates.Helper.ps1
@@ -23,7 +23,7 @@ function RemoveInternalsVisibleTo {
     )
 
     if ($settings.removeInternalsVisibleTo) {
-        $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "App\app.json"
+        $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "$($settings.appFolders[0])\app.json"
         $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
         
         $settingExists = [bool] ($appFileJson.PSObject.Properties.Name -eq 'internalsVisibleTo')
@@ -50,7 +50,7 @@ function OverrideResourceExposurePolicy {
     )
 
     if ($settings.overrideResourceExposurePolicy) {
-        $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "App\app.json"
+        $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "$($settings.appFolders[0])\app.json"
         $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
     
         $resourceExposurePolicySpecified = [bool] ($appFileJson.PSObject.Properties.Name -eq 'resourceExposurePolicy')
@@ -91,7 +91,7 @@ function UpdateVersion {
         [PSCustomObject]$settings
     )
 
-    $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "App\app.json"
+    $appJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "$($settings.appFolders[0])\app.json"
     $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
 
     $existingVersionAsArray = [Version]$appFileJson.version

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -3,6 +3,7 @@
 function Set-GitUser {
     invoke-git config --global user.email "BCDevOpsFlows@dev.azure.com"
     invoke-git config --global user.name "BCDevOps Flows Pipeline"
+    invoke-git config --global core.ignoreCase true
 }
 function Invoke-RestoreUnstagedChanges {
     Param(

--- a/IncrementVersion/IncrementVersion.ps1
+++ b/IncrementVersion/IncrementVersion.ps1
@@ -80,7 +80,7 @@ try {
 
     # Find repository settings 
     $repositorySettings = ReadSettings -baseFolder $baseFolder
-    $appFilePath = Join-Path $baseFolder "App\app.json"
+    $appFilePath = Join-Path $baseFolder "$($settings.appFolders[0])\app.json"
 
     # Restore unstaged changes for changed file
     Invoke-RestoreUnstagedChanges -appFilePath $appFilePath


### PR DESCRIPTION
This pull request updates several PowerShell scripts to improve flexibility and configuration handling by dynamically determining the `app.json` file path based on settings, and introduces a minor Git configuration enhancement. Below is a summary of the most important changes:

### Dynamic `app.json` File Path Resolution:
* Updated multiple functions in `.Internal/ApplyAppJsonUpdates.Helper.ps1` (`RemoveInternalsVisibleTo`, `OverrideResourceExposurePolicy`, and `UpdateVersion`) to construct the `app.json` file path dynamically using the first folder specified in `$settings.appFolders` instead of hardcoding the path to "App\app.json". [[1]](diffhunk://#diff-9cde32eeb804a6d5e07db43493c0da4fe3e1f215f8d921ec967a6e8b74e71295L26-R26) [[2]](diffhunk://#diff-9cde32eeb804a6d5e07db43493c0da4fe3e1f215f8d921ec967a6e8b74e71295L53-R53) [[3]](diffhunk://#diff-9cde32eeb804a6d5e07db43493c0da4fe3e1f215f8d921ec967a6e8b74e71295L94-R94)
* Modified the `IncrementVersion.ps1` script to leverage the same dynamic approach for resolving the `app.json` file path.

### Git Configuration Enhancement:
* Added a new global Git configuration (`core.ignoreCase`) in `.Internal/GitHelper.Helper.ps1` to ensure case-insensitive file handling in Git operations.