### PR TITLE
GetExtendedErrorMessage not found

### DIFF
--- a/.Internal/Common/Download-File.ps1
+++ b/.Internal/Common/Download-File.ps1
@@ -20,9 +20,9 @@
 #>
 function Download-File {
     Param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string] $sourceUrl,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string] $destinationFile,
         [string] $description = '',
         [hashtable] $headers = @{"UserAgent" = "BcContainerHelper $bcContainerHelperVersion" },
@@ -81,13 +81,13 @@ function Download-File {
     }
 
     $replaceUrls = @{
-        "https://go.microsoft.com/fwlink/?LinkID=844461" = "https://bcartifacts.azureedge.net/prerequisites/DotNetCore.1.0.4_1.1.1-WindowsHosting.exe"
-        "https://download.microsoft.com/download/C/9/E/C9E8180D-4E51-40A6-A9BF-776990D8BCA9/rewrite_amd64.msi" = "https://bcartifacts.azureedge.net/prerequisites/rewrite_2.0_rtw_x64.msi"
-        "https://download.microsoft.com/download/5/5/3/553C731E-9333-40FB-ADE3-E02DC9643B31/OpenXMLSDKV25.msi" = "https://bcartifacts.azureedge.net/prerequisites/OpenXMLSDKv25.msi"
-        "https://download.microsoft.com/download/A/1/2/A129F694-233C-4C7C-860F-F73139CF2E01/ENU/x86/ReportViewer.msi" = "https://bcartifacts.azureedge.net/prerequisites/ReportViewer.msi"
+        "https://go.microsoft.com/fwlink/?LinkID=844461"                                                                = "https://bcartifacts.azureedge.net/prerequisites/DotNetCore.1.0.4_1.1.1-WindowsHosting.exe"
+        "https://download.microsoft.com/download/C/9/E/C9E8180D-4E51-40A6-A9BF-776990D8BCA9/rewrite_amd64.msi"          = "https://bcartifacts.azureedge.net/prerequisites/rewrite_2.0_rtw_x64.msi"
+        "https://download.microsoft.com/download/5/5/3/553C731E-9333-40FB-ADE3-E02DC9643B31/OpenXMLSDKV25.msi"          = "https://bcartifacts.azureedge.net/prerequisites/OpenXMLSDKv25.msi"
+        "https://download.microsoft.com/download/A/1/2/A129F694-233C-4C7C-860F-F73139CF2E01/ENU/x86/ReportViewer.msi"   = "https://bcartifacts.azureedge.net/prerequisites/ReportViewer.msi"
         "https://download.microsoft.com/download/1/3/0/13089488-91FC-4E22-AD68-5BE58BD5C014/ENU/x86/SQLSysClrTypes.msi" = "https://bcartifacts.azureedge.net/prerequisites/SQLSysClrTypes.msi"
-        "https://download.microsoft.com/download/3/A/6/3A632674-A016-4E31-A675-94BE390EA739/ENU/x64/sqlncli.msi" = "https://bcartifacts.azureedge.net/prerequisites/sqlncli.msi"
-        "https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe" = "https://bcartifacts.azureedge.net/prerequisites/vcredist_x86.exe"
+        "https://download.microsoft.com/download/3/A/6/3A632674-A016-4E31-A675-94BE390EA739/ENU/x64/sqlncli.msi"        = "https://bcartifacts.azureedge.net/prerequisites/sqlncli.msi"
+        "https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe"           = "https://bcartifacts.azureedge.net/prerequisites/vcredist_x86.exe"
     }
 
     if ($replaceUrls.ContainsKey($sourceUrl)) {
@@ -95,7 +95,7 @@ function Download-File {
     }
 
     # If DropBox URL with dl=0 - replace with dl=1 (direct download = common mistake)
-    if ($sourceUrl.StartsWith("https://www.dropbox.com/","InvariantCultureIgnoreCase") -and $sourceUrl.EndsWith("?dl=0","InvariantCultureIgnoreCase")) {
+    if ($sourceUrl.StartsWith("https://www.dropbox.com/", "InvariantCultureIgnoreCase") -and $sourceUrl.EndsWith("?dl=0", "InvariantCultureIgnoreCase")) {
         $sourceUrl = "$($sourceUrl.Substring(0, $sourceUrl.Length-1))1"
     }
 
@@ -130,7 +130,13 @@ function Download-File {
             catch {
                 $waitTime += $waitTime
                 if ($_.Exception.Message -like '*404*' -or $waitTime -gt 60) {
-                    throw (GetExtendedErrorMessage $_)
+                    Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"
+                    Write-Host $_.ScriptStackTrace
+                    if ($_.PSMessageDetails) {
+                        Write-Host $_.PSMessageDetails
+                    }
+                    Write-Host "##vso[task.complete result=Failed]"
+                    throw ($_.Exception.Message)
                 }
                 Write-Host "Error downloading..., retrying in $waitTime seconds..."
                 Start-Sleep -Seconds $waitTime

--- a/.Internal/NuGet/BcDevOpsFlowsNuGetFeedClass.ps1
+++ b/.Internal/NuGet/BcDevOpsFlowsNuGetFeedClass.ps1
@@ -46,7 +46,13 @@ class BcDevOpsFlowsNuGetFeed {
             Write-Verbose "- PackageBaseAddress=$($this.packageBaseAddressUrl)"
         }
         catch {
-            throw (GetExtendedErrorMessage $_)
+            Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"
+            Write-Host $_.ScriptStackTrace
+            if ($_.PSMessageDetails) {
+                Write-Host $_.PSMessageDetails
+            }
+            Write-Host "##vso[task.complete result=Failed]"
+            throw ($_.Exception.Message)
         }
     }
 
@@ -127,7 +133,13 @@ class BcDevOpsFlowsNuGetFeed {
                 $global:ProgressPreference = $prev
             }
             catch {
-                throw (GetExtendedErrorMessage $_)
+                Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"
+                Write-Host $_.ScriptStackTrace
+                if ($_.PSMessageDetails) {
+                    Write-Host $_.PSMessageDetails
+                }
+                Write-Host "##vso[task.complete result=Failed]"
+                throw ($_.Exception.Message)
             }
             # Check that the found pattern matches the package name and the trusted patterns
             $matching = @($searchResult.data | Where-Object { $_.id -like "*$($packageName)*" -and $this.IsTrusted($_.id) } | Sort-Object { $_.id.replace('.symbols', '') } | ForEach-Object { @{ "id" = $_.id; "versions" = @($_.versions.version) } } )
@@ -159,7 +171,13 @@ class BcDevOpsFlowsNuGetFeed {
                 $global:ProgressPreference = $prev
             }
             catch {
-                throw (GetExtendedErrorMessage $_)
+                Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"
+                Write-Host $_.ScriptStackTrace
+                if ($_.PSMessageDetails) {
+                    Write-Host $_.PSMessageDetails
+                }
+                Write-Host "##vso[task.complete result=Failed]"
+                throw ($_.Exception.Message)
             }
             $versionsArr = @($versions.versions)
     
@@ -304,7 +322,13 @@ class BcDevOpsFlowsNuGetFeed {
             $global:ProgressPreference = $prev
         }
         catch {
-            throw (GetExtendedErrorMessage $_)
+            Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"
+            Write-Host $_.ScriptStackTrace
+            if ($_.PSMessageDetails) {
+                Write-Host $_.PSMessageDetails
+            }
+            Write-Host "##vso[task.complete result=Failed]"
+            throw ($_.Exception.Message)
         }
         return [xml]$nuspec
     }
@@ -337,7 +361,13 @@ class BcDevOpsFlowsNuGetFeed {
             Write-Host "Package successfully downloaded"
         }
         catch {
-            throw (GetExtendedErrorMessage $_)
+            Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"
+            Write-Host $_.ScriptStackTrace
+            if ($_.PSMessageDetails) {
+                Write-Host $_.PSMessageDetails
+            }
+            Write-Host "##vso[task.complete result=Failed]"
+            throw ($_.Exception.Message)
         }
         return $tmpFolder
     }
@@ -379,15 +409,33 @@ class BcDevOpsFlowsNuGetFeed {
                     Write-Host -ForegroundColor Yellow "NuGet package already exists"
                 }
                 else {
-                    throw (GetExtendedErrorMessage $_)
+                    Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"
+                    Write-Host $_.ScriptStackTrace
+                    if ($_.PSMessageDetails) {
+                        Write-Host $_.PSMessageDetails
+                    }
+                    Write-Host "##vso[task.complete result=Failed]"
+                    throw ($_.Exception.Message)
                 }
             }
             else {
-                throw (GetExtendedErrorMessage $_)
+                Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"
+                Write-Host $_.ScriptStackTrace
+                if ($_.PSMessageDetails) {
+                    Write-Host $_.PSMessageDetails
+                }
+                Write-Host "##vso[task.complete result=Failed]"
+                throw ($_.Exception.Message)
             }
         }
         catch {
-            throw (GetExtendedErrorMessage $_)
+            Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"
+            Write-Host $_.ScriptStackTrace
+            if ($_.PSMessageDetails) {
+                Write-Host $_.PSMessageDetails
+            }
+            Write-Host "##vso[task.complete result=Failed]"
+            throw ($_.Exception.Message)
         }
         finally {
             Remove-Item $tmpFile -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
This pull request improves error handling in PowerShell scripts by replacing the `GetExtendedErrorMessage` function with detailed logging statements for Azure DevOps pipelines. The changes ensure that error messages, stack traces, and additional details are logged before re-throwing exceptions, providing better insights into failures.

### Enhanced Error Logging for Azure DevOps Pipelines:
* Updated error handling in the `Download-File` function to log the exception message, script stack trace, and additional details (if available) using Azure DevOps pipeline logging commands. (`.Internal/Common/Download-File.ps1`, [.Internal/Common/Download-File.ps1L133-R139](diffhunk://#diff-a8e5b56cb11410c79f52ee78effd5f58e2ec5efaf9b41bede78c947a132f943fL133-R139))

* Replaced `GetExtendedErrorMessage` with detailed logging in multiple `catch` blocks of the `BcDevOpsFlowsNuGetFeed` class. This includes logging the exception message, stack trace, and any additional PowerShell message details, followed by marking the task as failed and re-throwing the exception. (`.Internal/NuGet/BcDevOpsFlowsNuGetFeedClass.ps1`, [[1]](diffhunk://#diff-bacb748b74c60ccf4f8c0dc676bd2c2598d5d440ad922933f65ba033f03e2151L49-R55) [[2]](diffhunk://#diff-bacb748b74c60ccf4f8c0dc676bd2c2598d5d440ad922933f65ba033f03e2151L130-R142) [[3]](diffhunk://#diff-bacb748b74c60ccf4f8c0dc676bd2c2598d5d440ad922933f65ba033f03e2151L162-R180) [[4]](diffhunk://#diff-bacb748b74c60ccf4f8c0dc676bd2c2598d5d440ad922933f65ba033f03e2151L307-R331) [[5]](diffhunk://#diff-bacb748b74c60ccf4f8c0dc676bd2c2598d5d440ad922933f65ba033f03e2151L340-R370) [[6]](diffhunk://#diff-bacb748b74c60ccf4f8c0dc676bd2c2598d5d440ad922933f65ba033f03e2151L382-R438)