### PR TITLE
Merge main to test branches

### DIFF
--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -1,3 +1,5 @@
+. (Join-Path -Path $PSScriptRoot -ChildPath "..\WriteOutput.Helper.ps1" -Resolve)
+
 function CmdDo {
     Param(
         [string] $command = "",
@@ -45,6 +47,8 @@ function CmdDo {
         }
         
         $message = $message.Trim()
+        OutputDebug -Message "Command output: $($message)"
+        OutputDebug -Message "Process: $($p | ConvertTo-Json -Depth 1)"
 
         if ($p.ExitCode -eq 0) {
             if (!$silent) {
@@ -69,6 +73,10 @@ function CmdDo {
     }
     catch [System.ComponentModel.Win32Exception] {
         if ($_.Exception.NativeErrorCode -eq 2) {
+            if ($returnSuccess) {
+                Write-Host "Error when executing command: $($_.Exception.Message)"
+                return $false
+            }
             if ($messageIfCmdNotFound) {
                 throw $messageIfCmdNotFound
             }
@@ -77,9 +85,12 @@ function CmdDo {
             }
         }
         else {
+            if ($returnSuccess) {
+                Write-Host "Error when executing command: $($_.Exception.Message)"
+                return $false
+            }
             throw
         }
-        return $false
     }
     finally {
         try { [Console]::OutputEncoding = $oldEncoding } catch {}

--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -55,6 +55,9 @@ function CmdDo {
                 $message.Replace("`r", "").Split("`n")
             }
             if ($returnSuccess) {
+                if ([string]::IsNullOrWhiteSpace($message)) { 
+                    return $false 
+                }
                 Write-Host "Command executed successfuly: $message"
                 return $true
             }

--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -54,9 +54,13 @@ function CmdDo {
             }
         }
         else {
+            if ($silent) {
+                return $false
+            }
             $message += "`n`nExitCode: " + $p.ExitCode + "`nCommandline: $command $arguments"
             throw $message
         }
+        return $true
     }
     catch [System.ComponentModel.Win32Exception] {
         if ($_.Exception.NativeErrorCode -eq 2) {
@@ -70,6 +74,7 @@ function CmdDo {
         else {
             throw
         }
+        return $false
     }
     finally {
         try { [Console]::OutputEncoding = $oldEncoding } catch {}

--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -53,6 +53,9 @@ function CmdDo {
             if ($returnValue) {
                 $message.Replace("`r", "").Split("`n")
             }
+            if ($returnSuccess) {
+                return $true
+            }
         }
         else {
             $message += "`n`nExitCode: " + $p.ExitCode + "`nCommandline: $command $arguments"
@@ -61,9 +64,6 @@ function CmdDo {
                 return $false
             }
             throw $message
-        }
-        if ($returnSuccess) {
-            return $true
         }
     }
     catch [System.ComponentModel.Win32Exception] {

--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -58,7 +58,7 @@ function CmdDo {
                 if ([string]::IsNullOrWhiteSpace($message)) { 
                     return $false 
                 }
-                Write-Host "Command executed successfuly: $message"
+                Write-Host "Command executed successfully: $message"
                 return $true
             }
         }

--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -47,9 +47,6 @@ function CmdDo {
         }
         
         $message = $message.Trim()
-        OutputDebug -Message "Command output: $($message)"
-        OutputDebug -Message "Process: $($p | ConvertTo-Json -Depth 1)"
-
         if ($p.ExitCode -eq 0) {
             if (!$silent) {
                 Write-Host $message
@@ -58,13 +55,13 @@ function CmdDo {
                 $message.Replace("`r", "").Split("`n")
             }
             if ($returnSuccess) {
+                Write-Host "Command executed successfuly: $message"
                 return $true
             }
         }
         else {
             $message += "`n`nExitCode: " + $p.ExitCode + "`nCommandline: $command $arguments"
             if ($returnSuccess) {
-                $p.ExitCode = 0
                 Write-Host "Error when executing command: $message"
                 return $false
             }

--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -54,7 +54,7 @@ function CmdDo {
             }
         }
         else {
-            if ($silent) {
+            if ($silent -and $returnValue) {
                 return $false
             }
             $message += "`n`nExitCode: " + $p.ExitCode + "`nCommandline: $command $arguments"

--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -57,6 +57,7 @@ function CmdDo {
         else {
             $message += "`n`nExitCode: " + $p.ExitCode + "`nCommandline: $command $arguments"
             if ($returnSuccess) {
+                $p.ExitCode = 0
                 return $false
             }
             throw $message

--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -61,6 +61,7 @@ function CmdDo {
             $message += "`n`nExitCode: " + $p.ExitCode + "`nCommandline: $command $arguments"
             if ($returnSuccess) {
                 $p.ExitCode = 0
+                Write-Host "Error when executing command: $message"
                 return $false
             }
             throw $message

--- a/.Internal/Common/CmdDo.ps1
+++ b/.Internal/Common/CmdDo.ps1
@@ -5,7 +5,8 @@ function CmdDo {
         [switch] $silent,
         [switch] $returnValue,
         [string] $inputStr = "",
-        [string] $messageIfCmdNotFound = ""
+        [string] $messageIfCmdNotFound = "",
+        [switch] $returnSuccess
     )
 
     $oldNoColor = "$env:NO_COLOR"
@@ -54,13 +55,15 @@ function CmdDo {
             }
         }
         else {
-            if ($silent -and $returnValue) {
+            $message += "`n`nExitCode: " + $p.ExitCode + "`nCommandline: $command $arguments"
+            if ($returnSuccess) {
                 return $false
             }
-            $message += "`n`nExitCode: " + $p.ExitCode + "`nCommandline: $command $arguments"
             throw $message
         }
-        return $true
+        if ($returnSuccess) {
+            return $true
+        }
     }
     catch [System.ComponentModel.Win32Exception] {
         if ($_.Exception.NativeErrorCode -eq 2) {

--- a/.Internal/Common/Invoke-git.ps1
+++ b/.Internal/Common/Invoke-git.ps1
@@ -24,6 +24,9 @@ function invoke-git {
                 $arguments += "$parameter "
             }
         }
-        cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -inputStr $inputStr -messageIfCmdNotFound "Git not found. Please install it from https://git-scm.com/downloads"
+        if ($arguments -contains '--exit-code') {
+            $silent = $true
+        }
+        return cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -inputStr $inputStr -messageIfCmdNotFound "Git not found. Please install it from https://git-scm.com/downloads"
     }
 }

--- a/.Internal/Common/Invoke-git.ps1
+++ b/.Internal/Common/Invoke-git.ps1
@@ -25,7 +25,7 @@ function invoke-git {
             }
         }
         if ($arguments -contains '--exit-code') {
-            $silent = $true
+            $arguments += " -returnSuccess"
         }
         return cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -inputStr $inputStr -messageIfCmdNotFound "Git not found. Please install it from https://git-scm.com/downloads"
     }

--- a/.Internal/Common/Invoke-git.ps1
+++ b/.Internal/Common/Invoke-git.ps1
@@ -1,4 +1,4 @@
-. (Join-Path -Path $PSScriptRoot -ChildPath ".\WriteOutput.Helper.ps1" -Resolve)
+. (Join-Path -Path $PSScriptRoot -ChildPath "..\WriteOutput.Helper.ps1" -Resolve)
 
 <# 
  .Synopsis

--- a/.Internal/Common/Invoke-git.ps1
+++ b/.Internal/Common/Invoke-git.ps1
@@ -10,8 +10,11 @@ function invoke-git {
         [string] $inputStr = "",
         [switch] $silent,
         [switch] $returnValue,
-        [parameter(mandatory = $true, position = 0)][string] $command,
-        [parameter(mandatory = $false, position = 1, ValueFromRemainingArguments = $true)] $remaining
+        [switch] $returnSuccess,
+        [parameter(mandatory = $true, position = 0)]
+        [string] $command,
+        [parameter(mandatory = $false, position = 1, ValueFromRemainingArguments = $true)] 
+        $remaining
     )
 
     Process {
@@ -24,9 +27,6 @@ function invoke-git {
                 $arguments += "$parameter "
             }
         }
-        if ($arguments -contains '--exit-code') {
-            $arguments += " -returnSuccess"
-        }
-        return cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -inputStr $inputStr -messageIfCmdNotFound "Git not found. Please install it from https://git-scm.com/downloads"
+        return cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -returnSuccess:$returnSuccess -inputStr $inputStr -messageIfCmdNotFound "Git not found. Please install it from https://git-scm.com/downloads"
     }
 }

--- a/.Internal/Common/Invoke-git.ps1
+++ b/.Internal/Common/Invoke-git.ps1
@@ -1,3 +1,5 @@
+. (Join-Path -Path $PSScriptRoot -ChildPath ".\WriteOutput.Helper.ps1" -Resolve)
+
 <# 
  .Synopsis
   Invoke git command with parameters
@@ -27,6 +29,11 @@ function invoke-git {
                 $arguments += "$parameter "
             }
         }
-        return cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -returnSuccess:$returnSuccess -inputStr $inputStr -messageIfCmdNotFound "Git not found. Please install it from https://git-scm.com/downloads"
+        if ($returnSuccess) {
+            $cmdDoResults = cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -returnSuccess -inputStr $inputStr -messageIfCmdNotFound "Git not found. Please install it from https://git-scm.com/downloads"
+            OutputDebug -Message "CmdDo results: $cmdDoResults"
+            return $cmdDoResults
+        }
+        cmdDo -command git -arguments $arguments -silent:$silent -returnValue:$returnValue -inputStr $inputStr -messageIfCmdNotFound "Git not found. Please install it from https://git-scm.com/downloads"
     }
 }

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -108,7 +108,8 @@ function Invoke-GitPushToTestBranches {
     }
     invoke-git fetch --all
     foreach ($branch in $targetBranches) {
-        if (invoke-git ls-remote --heads origin $branch -returnSuccess) {
+        $branchExists = invoke-git ls-remote --heads origin $branch -returnSuccess
+        if ($branchExists) {
             Write-Host "Merging to $branch branch"
             Invoke-GitPush -targetBranch "HEAD:$branch"
             Write-Host "Successfully merged to $branch"

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -111,7 +111,8 @@ function Invoke-GitMerge {
     invoke-git fetch --all
 
     $branch = 'test'
-    Invoke-RestoreUnstagedChanges -appFolderPath $ENV:BUILD_REPOSITORY_LOCALPATH
+    $appFolder = Join-Path $ENV:BUILD_REPOSITORY_LOCALPATH $($settings.appFolders[0])
+    Invoke-RestoreUnstagedChanges -appFolderPath $appFolder
     invoke-git switch $branch
     try {
         invoke-git merge $sourceBranchName --no-ff

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -108,7 +108,7 @@ function Invoke-GitPushToTestBranches {
     }
     invoke-git fetch --all
     foreach ($branch in $targetBranches) {
-        if (invoke-git ls-remote --exit-code --heads origin $branch) {
+        if (git ls-remote --exit-code --heads origin $branch) {
             Write-Host "Merging to $branch branch"
             Invoke-GitPush -targetBranch "HEAD:$branch"
             Write-Host "Successfully merged to $branch"
@@ -117,6 +117,7 @@ function Invoke-GitPushToTestBranches {
             OutputDebug -Message "Branch $branch does not exist, skipping..."
         }
     }
+    return 0 # override the default exit code from git ls-remote
 }
 function Invoke-GitAddCommit {
     Param(

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -108,7 +108,7 @@ function Invoke-GitPushToTestBranches {
     }
     invoke-git fetch --all
     foreach ($branch in $targetBranches) {
-        if (git ls-remote --exit-code --heads origin $branch) {
+        if (invoke-git ls-remote --exit-code --heads origin $branch) {
             Write-Host "Merging to $branch branch"
             Invoke-GitPush -targetBranch "HEAD:$branch"
             Write-Host "Successfully merged to $branch"

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -86,7 +86,8 @@ function Invoke-GitPush {
     invoke-git push origin $targetBranch
 
     if ($targetBranch -match "(HEAD:)?(main|master)$") {
-        Invoke-GitMerge -sourceBranch $targetBranch -targetBranches @('test', 'preview')
+        Invoke-GitPush -targetBranch "HEAD:test"
+        #Invoke-GitMerge -sourceBranch $targetBranch -targetBranches @('test', 'preview')
     }
 }
 function Invoke-GitMerge {
@@ -111,8 +112,7 @@ function Invoke-GitMerge {
     invoke-git fetch --all
 
     $branch = 'test'
-    $appFolder = Join-Path $ENV:BUILD_REPOSITORY_LOCALPATH $($settings.appFolders[0])
-    Invoke-RestoreUnstagedChanges -appFolderPath $appFolder
+    Invoke-RestoreUnstagedChanges -appFolderPath $ENV:BUILD_REPOSITORY_LOCALPATH
     invoke-git switch $branch
     try {
         invoke-git merge $sourceBranchName --no-ff

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -108,7 +108,7 @@ function Invoke-GitPushToTestBranches {
     }
     invoke-git fetch --all
     foreach ($branch in $targetBranches) {
-        if (git ls-remote --exit-code --heads origin $branch) {
+        if (invoke-git ls-remote --exit-code --heads origin $branch -returnValue) {
             Write-Host "Merging to $branch branch"
             Invoke-GitPush -targetBranch "HEAD:$branch"
             Write-Host "Successfully merged to $branch"

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -21,8 +21,8 @@ function Invoke-RestoreUnstagedChanges {
         invoke-git restore $appFilePath
     }
     else {
-        Get-ChildItem -Path $appFolderPath -Recurse | ForEach-Object {
-            OutputDebug -Message "Restoring unstaged changes for $($_.FullName))"
+        Get-ChildItem -Path $appFolderPath -Recurse -File | ForEach-Object {
+            OutputDebug -Message "Restoring unstaged changes for $($_.FullName)"
             invoke-git restore $_.FullName
         }
     }

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -110,7 +110,7 @@ function Invoke-GitMerge {
     }
 
     foreach ($branch in $targetBranches) {
-        $branchExists = invoke-git branch --list $branch
+        $branchExists = git branch --list $branch
         if ($branchExists) {
             Write-Host "Merging to $branch branch"
             try {

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -111,6 +111,7 @@ function Invoke-GitMerge {
 
     foreach ($branch in $targetBranches) {
         $branchExists = git branch --list $branch
+        OutputDebug -Message "Branch $branch exists: $branchExists"
         if ($branchExists) {
             Write-Host "Merging to $branch branch"
             try {

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -108,6 +108,7 @@ function Invoke-GitMerge {
         Write-Host "No target branches to merge into, skipping..."
         return
     }
+    invoke-git pull
 
     $branch = 'test'
     try {

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -109,29 +109,43 @@ function Invoke-GitMerge {
         return
     }
 
-    foreach ($branch in $targetBranches) {
-        $branchExists = git branch --list $branch
-        OutputDebug -Message "Branch $branch exists: $branchExists"
-        if ($branchExists) {
-            Write-Host "Merging to $branch branch"
-            try {
-                invoke-git checkout $branch
-                invoke-git merge $sourceBranchName --no-ff
-                Write-Host "Successfully merged to $branch"
-                Invoke-GitPush -targetBranch "HEAD:$branch"
-            }
-            catch {
-                Write-Warning "Failed to merge to $branch - $($_.Exception.Message)"
-                invoke-git merge --abort
-            }
-            finally {
-                invoke-git checkout $sourceBranchName
-            }
-        }
-        else {
-            OutputDebug -Message "Branch $branch does not exist, skipping..."
-        }
+    $branch = 'test'
+    try {
+        invoke-git checkout $branch
+        invoke-git merge $sourceBranchName --no-ff
+        Write-Host "Successfully merged to $branch"
+        Invoke-GitPush -targetBranch "HEAD:$branch"
     }
+    catch {
+        Write-Warning "Failed to merge to $branch - $($_.Exception.Message)"
+        invoke-git merge --abort
+    }
+    finally {
+        invoke-git checkout $sourceBranchName
+    }
+    # foreach ($branch in $targetBranches) {
+    #     $branchExists = git branch --list $branch
+    #     OutputDebug -Message "Branch $branch exists: $branchExists"
+    #     if ($branchExists) {
+    #         Write-Host "Merging to $branch branch"
+    #         try {
+    #             invoke-git checkout $branch
+    #             invoke-git merge $sourceBranchName --no-ff
+    #             Write-Host "Successfully merged to $branch"
+    #             Invoke-GitPush -targetBranch "HEAD:$branch"
+    #         }
+    #         catch {
+    #             Write-Warning "Failed to merge to $branch - $($_.Exception.Message)"
+    #             invoke-git merge --abort
+    #         }
+    #         finally {
+    #             invoke-git checkout $sourceBranchName
+    #         }
+    #     }
+    #     else {
+    #         OutputDebug -Message "Branch $branch does not exist, skipping..."
+    #     }
+    # }
 }
 function Invoke-GitAddCommit {
     Param(

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -108,7 +108,7 @@ function Invoke-GitPushToTestBranches {
     }
     invoke-git fetch --all
     foreach ($branch in $targetBranches) {
-        if (invoke-git ls-remote --exit-code --heads origin $branch -returnValue) {
+        if (invoke-git ls-remote --heads origin $branch -returnSuccess) {
             Write-Host "Merging to $branch branch"
             Invoke-GitPush -targetBranch "HEAD:$branch"
             Write-Host "Successfully merged to $branch"

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -112,7 +112,7 @@ function Invoke-GitMerge {
 
     $branch = 'test'
     try {
-        invoke-git checkout $branch
+        invoke-git switch $branch
         invoke-git merge $sourceBranchName --no-ff
         Write-Host "Successfully merged to $branch"
         Invoke-GitPush -targetBranch "HEAD:$branch"
@@ -122,7 +122,7 @@ function Invoke-GitMerge {
         invoke-git merge --abort
     }
     finally {
-        invoke-git checkout $sourceBranchName
+        invoke-git switch $sourceBranchName
     }
     # foreach ($branch in $targetBranches) {
     #     $branchExists = git branch --list $branch

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -111,8 +111,9 @@ function Invoke-GitMerge {
     invoke-git fetch --all
 
     $branch = 'test'
+    Invoke-RestoreUnstagedChanges -appFolderPath $ENV:BUILD_REPOSITORY_LOCALPATH
+    invoke-git switch $branch
     try {
-        invoke-git switch $branch
         invoke-git merge $sourceBranchName --no-ff
         Write-Host "Successfully merged to $branch"
         Invoke-GitPush -targetBranch "HEAD:$branch"

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -108,8 +108,7 @@ function Invoke-GitPushToTestBranches {
     }
     invoke-git fetch --all
     foreach ($branch in $targetBranches) {
-        $branchExists = git branch --list $branch
-        if ($branchExists) {
+        if (git ls-remote --exit-code --heads origin $branch) {
             Write-Host "Merging to $branch branch"
             Invoke-GitPush -targetBranch "HEAD:$branch"
             Write-Host "Successfully merged to $branch"

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -95,7 +95,7 @@ function Invoke-GitPushToTestBranches {
         [string[]] $targetBranches = @('test', 'preview')
     )
 
-    Write-Host "Merging changes to $targetBranches"
+    Write-Host "Merging changes to $($targetBranches -join ', ')"
     $sourceBranchName = $ENV:BUILD_SOURCEBRANCH.Split(':')[-1]
     if ($sourceBranchName -in $targetBranches) {
         Write-Host "Source branch $sourceBranchName is same as target branch, skipping it..."

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -85,7 +85,9 @@ function Invoke-GitPush {
     Write-Host "Pushing changes to $targetBranch"
     invoke-git push origin $targetBranch
 
-    Invoke-GitMerge -sourceBranch $targetBranch -targetBranches @('test', 'preview')
+    if ($targetBranch -match "(HEAD:)?(main|master)$") {
+        Invoke-GitMerge -sourceBranch $targetBranch -targetBranches @('test', 'preview')
+    }
 }
 function Invoke-GitMerge {
     param (

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -108,7 +108,7 @@ function Invoke-GitMerge {
         Write-Host "No target branches to merge into, skipping..."
         return
     }
-    invoke-git pull
+    invoke-git fetch --all
 
     $branch = 'test'
     try {


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to PowerShell scripts in the `.Internal` directory, focusing on improving command execution, error handling, and Git operations. The most notable changes include adding a new `-returnSuccess` switch for better success detection, refining file handling in Git operations, and introducing functionality to push changes to test branches automatically.

### Enhancements to command execution:
* Added a `-returnSuccess` switch to the `CmdDo` and `invoke-git` functions, allowing callers to determine the success of a command more explicitly. This includes returning `true` or `false` based on the command's outcome and providing detailed success/error messages. (`.Internal/Common/CmdDo.ps1` [[1]](diffhunk://#diff-21e9bf06404ffbc152cdf09ef68a00552491632a99047c4005872779e24e1b82R1-R11) [[2]](diffhunk://#diff-21e9bf06404ffbc152cdf09ef68a00552491632a99047c4005872779e24e1b82L47-R79) [[3]](diffhunk://#diff-21e9bf06404ffbc152cdf09ef68a00552491632a99047c4005872779e24e1b82R88-R91); `.Internal/Common/Invoke-git.ps1` [[4]](diffhunk://#diff-0bc1d5bd4bd461726b20df5a4d8ffe29a28224a95b51da2ebfc2da3d0436fbd4R1-R2) [[5]](diffhunk://#diff-0bc1d5bd4bd461726b20df5a4d8ffe29a28224a95b51da2ebfc2da3d0436fbd4L13-R19) [[6]](diffhunk://#diff-0bc1d5bd4bd461726b20df5a4d8ffe29a28224a95b51da2ebfc2da3d0436fbd4R32-R36)

### Improvements to Git operations:
* Refined the `invoke-git` function to leverage the new `-returnSuccess` switch for better error handling and debugging during Git command execution. (`.Internal/Common/Invoke-git.ps1` [.Internal/Common/Invoke-git.ps1R32-R36](diffhunk://#diff-0bc1d5bd4bd461726b20df5a4d8ffe29a28224a95b51da2ebfc2da3d0436fbd4R32-R36))
* Enhanced the `Invoke-RestoreUnstagedChanges` function to use the `-File` parameter with `Get-ChildItem`, ensuring only files (not directories) are restored. (`.Internal/GitHelper.Helper.ps1` [.Internal/GitHelper.Helper.ps1L24-R25](diffhunk://#diff-05354af9e44fc7c2e8f783b7cfbb98c64a76f686c7c60db58b0bd003c0d8b548L24-R25))
* Added a new `Invoke-GitPushToTestBranches` function, which automatically merges changes into test branches (`test` and `preview`) after pushing to `main` or `master`. This includes checks to skip merging if the source branch matches a target branch or if the target branch does not exist. (`.Internal/GitHelper.Helper.ps1` [.Internal/GitHelper.Helper.ps1R87-R121](diffhunk://#diff-05354af9e44fc7c2e8f783b7cfbb98c64a76f686c7c60db58b0bd003c0d8b548R87-R121))