### PR TITLE
Build info in app file, Preprocessor symbols with nuget

### DIFF
--- a/BuildWithNuget/BuildWithNuget.Helper.ps1
+++ b/BuildWithNuget/BuildWithNuget.Helper.ps1
@@ -6,6 +6,7 @@ function Assert-Prerequisites {
 
 function Get-BuildParameters {
     param (
+        $settings,
         [string]$baseRepoFolder,
         [string]$baseAppFolder,
         [string]$packageCachePath,
@@ -15,22 +16,40 @@ function Get-BuildParameters {
     $AppFileName = (("{0}_{1}_{2}.app" -f $appFileJson.publisher, $appFileJson.name, $appFileJson.version).Split([System.IO.Path]::GetInvalidFileNameChars()) -join '')
     $outputPath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath ".output"
 
-    return @(
-        "/project:`"$baseAppFolder`"",
-        "/packagecachepath:$packageCachePath",
-        "/out:`"$outputPath\$AppFileName`"",
+    $alcItem = Get-Item -Path (Join-Path $ENV:AL_BCDEVTOOLSFOLDER 'alc.exe')
+    [System.Version]$alcVersion = $alcItem.VersionInfo.FileVersion
+    $alcParameters = @(
+        "/project:""$baseAppFolder""", 
+        "/packagecachepath:""$packageCachePath""", 
+        "/out:""$outputPath\$AppFileName""",
         "/loglevel:Warning"
     )
+    if ($alcVersion -ge [System.Version]"12.0.12.41479") {
+        $alcParameters = @(
+            "sourceRepositoryUrl:""$ENV:BUILD_REPOSITORY_URI""",
+            "sourceCommit:""$ENV:BUILD_SOURCEVERSION""",
+            "buildBy:""BCDevOpsFlows""",
+            "buildUrl:""$ENV:BUILD_BUILDURI"""
+        )
+    }
+    if ($settings.ContainsKey('preprocessorSymbols')) {
+        Write-Host "Adding Preprocessor symbols : $($settings.preprocessorSymbols -join ',')"
+        $settings.preprocessorSymbols | where-Object { $_ } | ForEach-Object { $alcParameters += @("/D:$_") }
+    }
+    return $alcParameters
 }
 
 function Invoke-AlCompiler {
-    param([array]$Parameters)
+    param(
+        [array]$Parameters
+    )
 
     Write-Host "Using parameters:"
     $Parameters | ForEach-Object { Write-Host "  $_" }
 
     Push-Location
     try {
+        Write-Host ".\alc.exe $([string]::Join(' ', $Parameters))"
         Set-Location $ENV:AL_BCDEVTOOLSFOLDER
         & .\alc.exe $Parameters
     }

--- a/BuildWithNuget/BuildWithNuget.Helper.ps1
+++ b/BuildWithNuget/BuildWithNuget.Helper.ps1
@@ -26,10 +26,10 @@ function Get-BuildParameters {
     )
     if ($alcVersion -ge [System.Version]"12.0.12.41479") {
         $alcParameters += @(
-            "sourceRepositoryUrl:""$ENV:BUILD_REPOSITORY_URI""",
-            "sourceCommit:""$ENV:BUILD_SOURCEVERSION""",
-            "buildBy:""BCDevOpsFlows""",
-            "buildUrl:""$ENV:BUILD_BUILDURI"""
+            "/sourceRepositoryUrl:""$ENV:BUILD_REPOSITORY_URI""",
+            "/sourceCommit:""$ENV:BUILD_SOURCEVERSION""",
+            "/buildBy:""BCDevOpsFlows""",
+            "/buildUrl:""$ENV:BUILD_BUILDURI"""
         )
         Write-Host "Adding source code parameters:"
         Write-Host "  sourceRepositoryUrl: $ENV:BUILD_REPOSITORY_URI"

--- a/BuildWithNuget/BuildWithNuget.Helper.ps1
+++ b/BuildWithNuget/BuildWithNuget.Helper.ps1
@@ -25,12 +25,17 @@ function Get-BuildParameters {
         "/loglevel:Warning"
     )
     if ($alcVersion -ge [System.Version]"12.0.12.41479") {
-        $alcParameters = @(
+        $alcParameters += @(
             "sourceRepositoryUrl:""$ENV:BUILD_REPOSITORY_URI""",
             "sourceCommit:""$ENV:BUILD_SOURCEVERSION""",
             "buildBy:""BCDevOpsFlows""",
             "buildUrl:""$ENV:BUILD_BUILDURI"""
         )
+        Write-Host "Adding source code parameters:"
+        Write-Host "  sourceRepositoryUrl: $ENV:BUILD_REPOSITORY_URI"
+        Write-Host "  sourceCommit: $ENV:BUILD_SOURCEVERSION"
+        Write-Host "  buildBy: BCDevOpsFlows"
+        Write-Host "  buildUrl: $ENV:BUILD_BUILDURI"
     }
     if ($settings.ContainsKey('preprocessorSymbols')) {
         Write-Host "Adding Preprocessor symbols : $($settings.preprocessorSymbols -join ',')"

--- a/BuildWithNuget/BuildWithNuget.ps1
+++ b/BuildWithNuget/BuildWithNuget.ps1
@@ -30,7 +30,7 @@ try {
 
     $appFileJson = Get-Content "$baseAppFolder\app.json" -Encoding UTF8 | ConvertFrom-Json
 
-    $buildParameters = Get-BuildParameters -baseRepoFolder $baseRepoFolder -baseAppFolder $baseAppFolder -packageCachePath $buildCacheFolder -appFileJson $appFileJson
+    $buildParameters = Get-BuildParameters -settings $settings -baseRepoFolder $baseRepoFolder -baseAppFolder $baseAppFolder -packageCachePath $buildCacheFolder -appFileJson $appFileJson
     Invoke-AlCompiler -Parameters $buildParameters
 }
 catch {


### PR DESCRIPTION
This pull request enhances the build process for AL (Application Language) projects by introducing support for additional compiler parameters, conditional logic based on compiler version, and improved handling of preprocessor symbols. The changes aim to make the build process more flexible and informative.

### Enhancements to AL Compiler Parameter Handling:

* Updated `Get-BuildParameters` to dynamically construct `alc.exe` parameters based on the compiler version. If the version is `12.0.12.41479` or higher, additional metadata parameters (`sourceRepositoryUrl`, `sourceCommit`, `buildBy`, `buildUrl`) are included.
* Added support for preprocessor symbols in `Get-BuildParameters`. If the `settings` object contains `preprocessorSymbols`, these are appended to the compiler parameters. A log message is displayed listing the symbols being added.

### Code Refactoring and Improvements:

* Modified the `Invoke-AlCompiler` function to include a log statement that echoes the full `alc.exe` command for better debugging and transparency.
* Refactored the `Get-BuildParameters` function to simplify parameter handling and improve readability by separating parameter construction logic.

### Function Signature Updates:

* Updated the `Get-BuildParameters` function to accept a new `$settings` parameter, enabling the passing of additional configuration options like preprocessor symbols.
* Adjusted the call to `Get-BuildParameters` in `BuildWithNuget.ps1` to include the new `$settings` parameter.