### PR TITLE
Respect rulesets when building with NuGet

### DIFF
--- a/BuildWithNuget/BuildWithNuget.Helper.ps1
+++ b/BuildWithNuget/BuildWithNuget.Helper.ps1
@@ -1,3 +1,5 @@
+. (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\WriteOutput.Helper.ps1" -Resolve)
+
 function Assert-Prerequisites {
     if (!$ENV:AL_NUGETINITIALIZED) {
         throw "Nuget not initialized - make sure that the InitNuget pipeline step is configured to run before this step."
@@ -24,6 +26,14 @@ function Get-BuildParameters {
         "/out:""$outputPath\$AppFileName""",
         "/loglevel:Warning"
     )
+    if ($settings.rulesetFile) {
+        OutputDebug -Message "Adding custom ruleset: $($settings.rulesetFile)"
+        $alcParameters += @("/ruleset:$($settings.rulesetfile)")
+    }
+    if ($settings.enableExternalRulesets) {
+        OutputDebug -Message "Enabling external rulesets"
+        $alcParameters += @("/enableexternalrulesets")
+    }
     if ($alcVersion -ge [System.Version]"12.0.12.41479") {
         $alcParameters += @(
             "/sourceRepositoryUrl:""$ENV:BUILD_REPOSITORY_URI""",
@@ -31,14 +41,14 @@ function Get-BuildParameters {
             "/buildBy:""BCDevOpsFlows""",
             "/buildUrl:""$ENV:BUILD_BUILDURI"""
         )
-        Write-Host "Adding source code parameters:"
-        Write-Host "  sourceRepositoryUrl: $ENV:BUILD_REPOSITORY_URI"
-        Write-Host "  sourceCommit: $ENV:BUILD_SOURCEVERSION"
-        Write-Host "  buildBy: BCDevOpsFlows"
-        Write-Host "  buildUrl: $ENV:BUILD_BUILDURI"
+        OutputDebug -Message "Adding source code parameters:"
+        OutputDebug -Message "  sourceRepositoryUrl: $ENV:BUILD_REPOSITORY_URI"
+        OutputDebug -Message "  sourceCommit: $ENV:BUILD_SOURCEVERSION"
+        OutputDebug -Message "  buildBy: BCDevOpsFlows"
+        OutputDebug -Message "  buildUrl: $ENV:BUILD_BUILDURI"
     }
     if ($settings.ContainsKey('preprocessorSymbols')) {
-        Write-Host "Adding Preprocessor symbols : $($settings.preprocessorSymbols -join ',')"
+        OutputDebug -Message "Adding Preprocessor symbols : $($settings.preprocessorSymbols -join ',')"
         $settings.preprocessorSymbols | where-Object { $_ } | ForEach-Object { $alcParameters += @("/D:$_") }
     }
     return $alcParameters

--- a/BuildWithNuget/BuildWithNuget.Helper.ps1
+++ b/BuildWithNuget/BuildWithNuget.Helper.ps1
@@ -27,8 +27,9 @@ function Get-BuildParameters {
         "/loglevel:Warning"
     )
     if ($settings.rulesetFile) {
-        OutputDebug -Message "Adding custom ruleset: $($settings.rulesetFile)"
-        $alcParameters += @("/ruleset:$($settings.rulesetfile)")
+        $rulesetFilePath = Join-Path -Path $baseRepoFolder -ChildPath $settings.rulesetFile
+        OutputDebug -Message "Adding custom ruleset: $rulesetFilePath"
+        $alcParameters += @("/ruleset:$rulesetFilePath")
     }
     if ($settings.enableExternalRulesets) {
         OutputDebug -Message "Enabling external rulesets"

--- a/BuildWithNuget/BuildWithNuget.Helper.ps1
+++ b/BuildWithNuget/BuildWithNuget.Helper.ps1
@@ -28,8 +28,12 @@ function Get-BuildParameters {
     )
     if ($settings.rulesetFile) {
         $rulesetFilePath = Join-Path -Path $baseRepoFolder -ChildPath $settings.rulesetFile
-        OutputDebug -Message "Adding custom ruleset: $rulesetFilePath"
-        $alcParameters += @("/ruleset:$rulesetFilePath")
+        if (Test-Path -Path $rulesetFilePath) {
+            OutputDebug -Message "Adding custom ruleset: $rulesetFilePath"
+            $alcParameters += @("/ruleset:$rulesetFilePath")
+        } else {
+            throw "The specified ruleset file does not exist: $rulesetFilePath"
+        }
     }
     if ($settings.enableExternalRulesets) {
         OutputDebug -Message "Enabling external rulesets"


### PR DESCRIPTION
This pull request introduces improvements to the `BuildWithNuget.Helper.ps1` script by adding support for custom and external rulesets, enhancing debug output, and improving maintainability by reusing a shared helper script.

### Enhancements to build parameter handling:
* Added support for custom rulesets by checking for a `rulesetFile` setting and appending the `/ruleset` parameter with the corresponding file path.
* Enabled external rulesets when the `enableExternalRulesets` setting is true by appending the `/enableexternalrulesets` parameter.

### Debug output improvements:
* Replaced `Write-Host` calls with `OutputDebug` for more consistent and configurable debug messaging, including messages for source code parameters and preprocessor symbols.

### Code maintainability:
* Included the shared helper script `WriteOutput.Helper.ps1` to standardize output handling and reduce duplication.