### PR TITLE
NuGet determine BC dev tools latest version automatically

### DIFF
--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -17,7 +17,7 @@ try {
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
     $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion
 
-    $searchResults = Find-Package -Name Microsoft.Dynamics.BusinessCentral.Development.Tools -AllVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
+    $searchResults = Find-Package -Name Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
     Write-Host $searchResults
     $toolsVersion = $searchResults.Version
     if (-not $toolsVersion) {

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -17,7 +17,7 @@ try {
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
     $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion
 
-    $searchResults = Find-Package -Name Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
+    $searchResults = Find-Package Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -AllVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
     Write-Host $searchResults
     $toolsVersion = $searchResults.Version
     if (-not $toolsVersion) {

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -17,22 +17,13 @@ try {
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
     $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion
 
-    $searchResults = Find-Package Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -AllVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
-    Write-Host $searchResults
-    $toolsVersion = $searchResults.Version
-    if (-not $toolsVersion) {
-        throw "Could not determine BC Dev Tools version from Find-Package results"
+    if ([string]::IsNullOrEmpty($bcDevToolsPackageVersion)) {
+        $searchResults = Find-Package Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -AllVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
+        $bcDevToolsPackageVersion = $searchResults.Version
+        if ([string]::IsNullOrEmpty($bcDevToolsPackageVersion)) {
+            throw "Could not determine BC Dev Tools version from NuGet search results"
+        }
     }
-
-    # $searchResults = nuget search Microsoft.Dynamics.BusinessCentral.Development.Tools -PreRelease -Verbosity quiet -Take 1 -Source "https://api.nuget.org/v3/index.json"
-    # $toolsVersion = ($searchResults -split ' ')[1]
-    # if (-not $toolsVersion) {
-    #     throw "Could not determine BC Dev Tools version from NuGet search results"
-    # }
-    Write-Host "Found BC Dev Tools version: $toolsVersion"
-    
-    
-    throw "Debug"
 
     DownloadNugetPackage -packageName $bcDevToolsPackageName -packageVersion $bcDevToolsPackageVersion
 

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -12,12 +12,10 @@ try {
     }
 
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
+    $searchResults = Find-Package Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -AllVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
+    $bcDevToolsPackageVersion = $searchResults.Version
     if ([string]::IsNullOrEmpty($bcDevToolsPackageVersion)) {
-        $searchResults = Find-Package Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -AllVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
-        $bcDevToolsPackageVersion = $searchResults.Version
-        if ([string]::IsNullOrEmpty($bcDevToolsPackageVersion)) {
-            throw "Could not determine BC Dev Tools version from NuGet search results"
-        }
+        throw "Could not determine BC Dev Tools version from NuGet search results"
     }
 
     DownloadNugetPackage -packageName $bcDevToolsPackageName -packageVersion $bcDevToolsPackageVersion

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -17,7 +17,7 @@ try {
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
     $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion
 
-    nuget list Microsoft.Dynamics.BusinessCentral.Development.Tools -AllVersions
+    nuget search Microsoft.Dynamics.BusinessCentral.Development.Tools -Source "https://api.nuget.org/v3/index.json"
     throw "Debug"
 
     DownloadNugetPackage -packageName $bcDevToolsPackageName -packageVersion $bcDevToolsPackageVersion

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -17,7 +17,14 @@ try {
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
     $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion
 
-    nuget search Microsoft.Dynamics.BusinessCentral.Development.Tools -PreRelease -Source "https://api.nuget.org/v3/index.json"
+    $searchResults = nuget search Microsoft.Dynamics.BusinessCentral.Development.Tools -PreRelease -Verbosity quiet -Take 1 -Source "https://api.nuget.org/v3/index.json"
+    $toolsVersion = ($searchResults -split ' ')[1]
+    if (-not $toolsVersion) {
+        throw "Could not determine BC Dev Tools version from NuGet search results"
+    }
+    Write-Host "Found BC Dev Tools version: $toolsVersion"
+    
+    
     throw "Debug"
 
     DownloadNugetPackage -packageName $bcDevToolsPackageName -packageVersion $bcDevToolsPackageVersion

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -17,6 +17,9 @@ try {
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
     $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion
 
+    nuget list Microsoft.Dynamics.BusinessCentral.Development.Tools -AllVersions
+    throw "Debug"
+
     DownloadNugetPackage -packageName $bcDevToolsPackageName -packageVersion $bcDevToolsPackageVersion
 
     $bcDevToolsFolder = Join-Path -Path (GetNugetPackagePath -packageName $bcDevToolsPackageName -packageVersion $bcDevToolsPackageVersion) -ChildPath "Tools\net8.0\any"

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -12,7 +12,7 @@ try {
     }
 
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
-    $searchResults = Find-Package Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -AllVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
+    $searchResults = Find-Package Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -AllVersions -Source "https://api.nuget.org/v3/index.json" | Sort-Object Version -Descending | Select-Object -First 1
     $bcDevToolsPackageVersion = $searchResults.Version
     if ([string]::IsNullOrEmpty($bcDevToolsPackageVersion)) {
         throw "Could not determine BC Dev Tools version from NuGet search results"

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -17,7 +17,7 @@ try {
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
     $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion
 
-    nuget search Microsoft.Dynamics.BusinessCentral.Development.Tools -Source "https://api.nuget.org/v3/index.json"
+    nuget search Microsoft.Dynamics.BusinessCentral.Development.Tools -PreRelease -Source "https://api.nuget.org/v3/index.json"
     throw "Debug"
 
     DownloadNugetPackage -packageName $bcDevToolsPackageName -packageVersion $bcDevToolsPackageVersion

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -17,11 +17,18 @@ try {
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
     $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion
 
-    $searchResults = nuget search Microsoft.Dynamics.BusinessCentral.Development.Tools -PreRelease -Verbosity quiet -Take 1 -Source "https://api.nuget.org/v3/index.json"
-    $toolsVersion = ($searchResults -split ' ')[1]
+    $searchResults = Find-Package -Name Microsoft.Dynamics.BusinessCentral.Development.Tools -AllVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
+    Write-Host $searchResults
+    $toolsVersion = $searchResults.Version
     if (-not $toolsVersion) {
-        throw "Could not determine BC Dev Tools version from NuGet search results"
+        throw "Could not determine BC Dev Tools version from Find-Package results"
     }
+
+    # $searchResults = nuget search Microsoft.Dynamics.BusinessCentral.Development.Tools -PreRelease -Verbosity quiet -Take 1 -Source "https://api.nuget.org/v3/index.json"
+    # $toolsVersion = ($searchResults -split ' ')[1]
+    # if (-not $toolsVersion) {
+    #     throw "Could not determine BC Dev Tools version from NuGet search results"
+    # }
     Write-Host "Found BC Dev Tools version: $toolsVersion"
     
     

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -10,9 +10,6 @@ try {
     if (!$settings) {
         throw "Settings not found - make sure that the ReadSettings pipeline step is configured to run before this step."
     }
-    if (!$settings.nugetBCDevToolsVersion) {
-        throw "Nuget package version not found in settings file. Do not specify 'nugetBCDevToolsVersion' in setting files to use the default version."
-    }
 
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
     $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion

--- a/InitNuget/InitNuget.ps1
+++ b/InitNuget/InitNuget.ps1
@@ -12,8 +12,6 @@ try {
     }
 
     $bcDevToolsPackageName = "Microsoft.Dynamics.BusinessCentral.Development.Tools"
-    $bcDevToolsPackageVersion = $settings.nugetBCDevToolsVersion
-
     if ([string]::IsNullOrEmpty($bcDevToolsPackageVersion)) {
         $searchResults = Find-Package Microsoft.Dynamics.BusinessCentral.Development.Tools -AllowPrereleaseVersions -AllVersions -Source "https://api.nuget.org/v3/index.json" | Select-Object -First 1
         $bcDevToolsPackageVersion = $searchResults.Version

--- a/ReadSettings/ReadSettings.Helper.ps1
+++ b/ReadSettings/ReadSettings.Helper.ps1
@@ -110,7 +110,6 @@ function ReadSettings {
         "cacheKeepDays"                               = 3
         "buildModes"                                  = @()
         "writableFolderPath"                          = ""
-        "nugetBCDevToolsVersion"                      = ""   
         "trustMicrosoftNuGetFeeds"                    = $true
         "artifactUrlCacheKeepHours"                   = 6
         "overrideResourceExposurePolicy"              = $false

--- a/ReadSettings/ReadSettings.Helper.ps1
+++ b/ReadSettings/ReadSettings.Helper.ps1
@@ -110,7 +110,7 @@ function ReadSettings {
         "cacheKeepDays"                               = 3
         "buildModes"                                  = @()
         "writableFolderPath"                          = ""
-        "nugetBCDevToolsVersion"                      = "15.0.18.19684-beta"   
+        "nugetBCDevToolsVersion"                      = ""   
         "trustMicrosoftNuGetFeeds"                    = $true
         "artifactUrlCacheKeepHours"                   = 6
         "overrideResourceExposurePolicy"              = $false


### PR DESCRIPTION
This pull request updates the handling of the Business Central Development Tools NuGet package version in the PowerShell scripts. The changes ensure the version is dynamically determined if not explicitly provided, simplifying configuration and improving flexibility.

### Updates to NuGet package version handling:

* [`InitNuget/InitNuget.ps1`](diffhunk://#diff-8f61143aec0c75e28b04ade517c64aa905454e4991d10adc3b867b44562cd885L13-R21): Removed the requirement for `nugetBCDevToolsVersion` in the settings file. The script now dynamically searches NuGet for the latest version of the `Microsoft.Dynamics.BusinessCentral.Development.Tools` package if the version is not specified. Added error handling to ensure a valid version is retrieved.

* [`ReadSettings/ReadSettings.Helper.ps1`](diffhunk://#diff-f68e0b52fd2750401b799b2cf2698a2d3795379fce9ea2ac077e2e6aaf912b06L113): Removed the default `nugetBCDevToolsVersion` value from the settings template, reflecting the shift to dynamic version resolution.