### PR TITLE
Setup pipelines push to all branches

### DIFF
--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -134,7 +134,7 @@ function Invoke-GitPushToAllBranches {
     invoke-git fetch --all
 
     # Get all remote branches
-    $branches = invoke-git branch -r | ForEach-Object { $_.Trim() } | Where-Object { 
+    $branches = invoke-git branch --remotes | ForEach-Object { $_.Trim() } | Where-Object { 
         $_ -match "^origin/" -and 
         $_ -notmatch "HEAD" -and 
         $_ -notmatch $skipPattern 

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -131,10 +131,11 @@ function Invoke-GitPushToAllBranches {
     invoke-git fetch --all
 
     # Get all remote branches
-    $branches = invoke-git branch --remotes | ForEach-Object { $_.Trim() } | Where-Object { 
+    $branches = git branch --remotes | ForEach-Object { $_.Trim() } | Where-Object { 
         $_ -match "^origin/" -and 
         $_ -notmatch "HEAD"
     } | ForEach-Object { $_.Replace("origin/", "") }
+Write-Host "Branches to push: $($branches -join ', ')"
 
     foreach ($branch in $branches) {
         Write-Host "Pushing to $branch branch"

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -139,7 +139,7 @@ function Invoke-GitPushToAllBranches {
     foreach ($branch in $branches) {
         Write-Host "Pushing to $branch branch"
         try {
-            Invoke-GitPush -targetBranch "HEAD:$branch"
+            invoke-git push origin $branch
             Write-Host "Successfully pushed to $branch"
         }
         catch {

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -135,13 +135,17 @@ function Invoke-GitPushToAllBranches {
         $_ -match "^origin/" -and 
         $_ -notmatch "HEAD"
     } | ForEach-Object { $_.Replace("origin/", "") }
-Write-Host "Branches to push: $($branches -join ', ')"
-
+    $detachedBranches = $branches | Where-Object { $_ -match '^\s*\w{40}' } | ForEach-Object { $_.Trim() }
+    if ($detachedBranches) {
+        Write-Host "Skipping detached HEAD branches: $($detachedBranches -join ', ')"
+    }
+    $branches = $branches | Where-Object { $_ -notin $detachedBranches }
+    
     foreach ($branch in $branches) {
         Write-Host "Pushing to $branch branch"
         try {
-            invoke-git push origin $branch
-            Write-Host "Successfully pushed to $branch"
+            invoke-git push origin "HEAD:$branch"
+            Write-Host "Successfully pushed to HEAD:$branch"
         }
         catch {
             Write-Host "Failed to push to $($branch): $($_.Exception.Message)" -ForegroundColor Yellow

--- a/.Internal/GitHelper.Helper.ps1
+++ b/.Internal/GitHelper.Helper.ps1
@@ -125,10 +125,7 @@ function Invoke-GitPushToTestBranches {
     return 0 # override the default exit code from git ls-remote
 }
 function Invoke-GitPushToAllBranches {
-    param (
-        [Parameter(Mandatory = $false)]
-        [string] $skipPattern = ""
-    )
+    param ()
 
     Write-Host "Pushing changes to all branches"
     invoke-git fetch --all
@@ -136,8 +133,7 @@ function Invoke-GitPushToAllBranches {
     # Get all remote branches
     $branches = invoke-git branch --remotes | ForEach-Object { $_.Trim() } | Where-Object { 
         $_ -match "^origin/" -and 
-        $_ -notmatch "HEAD" -and 
-        $_ -notmatch $skipPattern 
+        $_ -notmatch "HEAD"
     } | ForEach-Object { $_.Replace("origin/", "") }
 
     foreach ($branch in $branches) {


### PR DESCRIPTION
This pull request introduces functionality to push changes to all branches when the pipeline name is `SetupPipelines`. The changes include adding a new function `Invoke-GitPushToAllBranches` and modifying the behavior of the `Invoke-GitPush` function to conditionally call this new function.

### New functionality for pushing to all branches:
* [`.Internal/GitHelper.Helper.ps1`](diffhunk://#diff-05354af9e44fc7c2e8f783b7cfbb98c64a76f686c7c60db58b0bd003c0d8b548R127-R156): Added a new function `Invoke-GitPushToAllBranches` that fetches all remote branches, filters out detached HEAD branches, and iteratively pushes changes to each branch. It includes error handling to skip branches with push failures.

### Conditional invocation of the new function:
* [`.Internal/GitHelper.Helper.ps1`](diffhunk://#diff-05354af9e44fc7c2e8f783b7cfbb98c64a76f686c7c60db58b0bd003c0d8b548R85-L87): Updated the `Invoke-GitPush` function to call `Invoke-GitPushToAllBranches` and return early if the pipeline name is `SetupPipelines`.