### PR TITLE
Update AppSourceCop.json autokamtically

### DIFF
--- a/IncrementVersion/IncrementVersion.Helper.ps1
+++ b/IncrementVersion/IncrementVersion.Helper.ps1
@@ -210,3 +210,23 @@ function Update-AppSourceCopJson {
         Set-JsonContentLF -Path $appSourceCopJsonFilePath -object $appSourceCopJson
     }
 }
+function Restore-AppSourceCopJson {
+    Param(
+        [Parameter(Mandatory)]
+        [string] $appSourceCopJsonFilePath,
+        [Parameter(Mandatory)]
+        [PSCustomObject] $originalAppSourceCopJsonContent
+    )
+
+    if ($settings.enableAppSourceCop) {
+        if (Test-Path $appSourceCopJsonFilePath) {
+            Remove-Item -Path $appSourceCopJsonFilePath -Force
+        }
+
+        Write-Host "Restoring original AppSourceCop.json"
+        Write-Host "Removing version from original AppSourceCop.json content"
+        $appSourceCopJson = $originalAppSourceCopJsonContent | Select-Object -Property * -ExcludeProperty version
+
+        Set-JsonContentLF -Path $appSourceCopJsonFilePath -object $appSourceCopJson
+    }
+}

--- a/IncrementVersion/IncrementVersion.Helper.ps1
+++ b/IncrementVersion/IncrementVersion.Helper.ps1
@@ -31,7 +31,7 @@ function Set-VersionInSettingsFile {
         [Parameter(Mandatory = $true)]
         [string] $settingName,
         [Parameter(Mandatory = $true)]
-        [string] $newValue,
+        [string] $newValue, 
         [switch] $Force
     )
 
@@ -184,4 +184,29 @@ function Set-VersionInAppManifests($appFilePath, $settings, $newValue) {
     $newVersion = Set-VersionInSettingsFile -settingsFilePath $appFilePath -settingName 'version' -newValue $newValue
     OutputDebug -Message "New version applied to app.json: $newVersion"
     return $newVersion
+}
+function Update-AppSourceCopJson {
+    Param(
+        [Parameter(Mandatory)]
+        [string] $appJsonFilePath,
+        [Parameter(Mandatory)]
+        [string] $appSourceCopJsonFilePath,
+        [Parameter(Mandatory)]
+        [PSCustomObject] $settings
+    )
+
+    if ($settings.enableAppSourceCop) {
+        $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
+        if (Test-Path $appSourceCopJsonFilePath) {
+            $appSourceCopJson = Get-Content $appSourceCopJsonFilePath -Raw | ConvertFrom-Json
+        }
+        else {
+            $appSourceCopJson = [PSCustomObject]@{}
+        }
+        Write-Host "Updating AppSourceCop.json file to $(appFileJson.name) version $($appFileJson.version) by $($appFileJson.publisher)"
+        $appSourceCopJson | Add-Member -MemberType NoteProperty -Name 'name' -Value $appFileJson.name -Force
+        $appSourceCopJson | Add-Member -MemberType NoteProperty -Name 'publisher' -Value $appFileJson.publisher -Force
+        $appSourceCopJson | Add-Member -MemberType NoteProperty -Name 'version' -Value $appFileJson.version -Force
+        Set-JsonContentLF -Path $appSourceCopJsonFilePath -object $appSourceCopJson
+    }
 }

--- a/IncrementVersion/IncrementVersion.Helper.ps1
+++ b/IncrementVersion/IncrementVersion.Helper.ps1
@@ -215,7 +215,9 @@ function Restore-AppSourceCopJson {
         [Parameter(Mandatory)]
         [string] $appSourceCopJsonFilePath,
         [Parameter(Mandatory)]
-        [PSCustomObject] $originalAppSourceCopJsonContent
+        [PSCustomObject] $originalAppSourceCopJsonContent,
+        [Parameter(Mandatory)]
+        [PSCustomObject] $settings
     )
 
     if ($settings.enableAppSourceCop) {

--- a/IncrementVersion/IncrementVersion.Helper.ps1
+++ b/IncrementVersion/IncrementVersion.Helper.ps1
@@ -196,7 +196,7 @@ function Update-AppSourceCopJson {
     )
 
     if ($settings.enableAppSourceCop) {
-        $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
+        $appFileJson = Get-Content $appJsonFilePath -Encoding UTF8 -Raw | ConvertFrom-Json 
         if (Test-Path $appSourceCopJsonFilePath) {
             $appSourceCopJson = Get-Content $appSourceCopJsonFilePath -Raw | ConvertFrom-Json
         }

--- a/IncrementVersion/IncrementVersion.Helper.ps1
+++ b/IncrementVersion/IncrementVersion.Helper.ps1
@@ -203,7 +203,7 @@ function Update-AppSourceCopJson {
         else {
             $appSourceCopJson = [PSCustomObject]@{}
         }
-        Write-Host "Updating AppSourceCop.json file to $(appFileJson.name) version $($appFileJson.version) by $($appFileJson.publisher)"
+        Write-Host "Updating AppSourceCop.json file to $($appFileJson.name) version $($appFileJson.version) by $($appFileJson.publisher)"
         $appSourceCopJson | Add-Member -MemberType NoteProperty -Name 'name' -Value $appFileJson.name -Force
         $appSourceCopJson | Add-Member -MemberType NoteProperty -Name 'publisher' -Value $appFileJson.publisher -Force
         $appSourceCopJson | Add-Member -MemberType NoteProperty -Name 'version' -Value $appFileJson.version -Force

--- a/IncrementVersion/IncrementVersion.ps1
+++ b/IncrementVersion/IncrementVersion.ps1
@@ -8,6 +8,7 @@ Param(
 . (Join-Path -Path $PSScriptRoot -ChildPath "IncrementVersion.Helper.ps1" -Resolve)
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\BCDevOpsFlows.Setup.ps1" -Resolve)
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\GitHelper.Helper.ps1" -Resolve)
+. (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\WriteSettings.Helper.ps1" -Resolve)
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\ReadSettings\ReadSettings.Helper.ps1" -Resolve)
 
 try {
@@ -90,7 +91,8 @@ try {
 
     # Update AppSourceCop json
     $appSourceCopJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "$($settings.appFolders[0])\AppSourceCop.json"
-    Invoke-RestoreUnstagedChanges -appFilePath $appFilePath
+    $originalAppSourceCopJson = Get-Content $appSourceCopJsonFilePath -Raw | ConvertFrom-Json
+    Invoke-RestoreUnstagedChanges -appFilePath $appSourceCopJsonFilePath
     Update-AppSourceCopJson -appJsonFilePath $appFilePath -appSourceCopJsonFilePath $appSourceCopJsonFilePath -settings $settings
 
     # Commit changes
@@ -98,10 +100,11 @@ try {
     Invoke-GitAdd -appFilePath $repositorySettingsPath
     Invoke-GitAddCommit -appFilePath $appFilePath -commitMessage "Updating version to $newAppliedVersion"
 
-    # Delete AppSourceCop to skip validation in this build
+    # Delete AppSourceCop to skip validation in this build and restore the original AppSourceCop.json
     if (Test-Path $appSourceCopJsonFilePath) {
         Remove-Item -Path $appSourceCopJsonFilePath -Force
     }
+    Set-JsonContentLF -Path $appSourceCopJsonFilePath -object $originalAppSourceCopJson
 }
 catch {
     Write-Host "##vso[task.logissue type=error]Error while updating app.json or pushing changes to Azure DevOps. Error message: $($_.Exception.Message)"

--- a/IncrementVersion/IncrementVersion.ps1
+++ b/IncrementVersion/IncrementVersion.ps1
@@ -97,6 +97,11 @@ try {
     Invoke-GitAdd -appFilePath $appSourceCopJsonFilePath
     Invoke-GitAdd -appFilePath $repositorySettingsPath
     Invoke-GitAddCommit -appFilePath $appFilePath -commitMessage "Updating version to $newAppliedVersion"
+
+    # Delete AppSourceCop to skip validation in this build
+    if (Test-Path $appSourceCopJsonFilePath) {
+        Remove-Item -Path $appSourceCopJsonFilePath -Force
+    }
 }
 catch {
     Write-Host "##vso[task.logissue type=error]Error while updating app.json or pushing changes to Azure DevOps. Error message: $($_.Exception.Message)"

--- a/IncrementVersion/IncrementVersion.ps1
+++ b/IncrementVersion/IncrementVersion.ps1
@@ -8,7 +8,6 @@ Param(
 . (Join-Path -Path $PSScriptRoot -ChildPath "IncrementVersion.Helper.ps1" -Resolve)
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\BCDevOpsFlows.Setup.ps1" -Resolve)
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\GitHelper.Helper.ps1" -Resolve)
-. (Join-Path -Path $PSScriptRoot -ChildPath "..\.Internal\WriteSettings.Helper.ps1" -Resolve)
 . (Join-Path -Path $PSScriptRoot -ChildPath "..\ReadSettings\ReadSettings.Helper.ps1" -Resolve)
 
 try {
@@ -101,10 +100,7 @@ try {
     Invoke-GitAddCommit -appFilePath $appFilePath -commitMessage "Updating version to $newAppliedVersion"
 
     # Delete AppSourceCop to skip validation in this build and restore the original AppSourceCop.json
-    if (Test-Path $appSourceCopJsonFilePath) {
-        Remove-Item -Path $appSourceCopJsonFilePath -Force
-    }
-    Set-JsonContentLF -Path $appSourceCopJsonFilePath -object $originalAppSourceCopJson
+    Restore-AppSourceCopJson -appSourceCopJsonFilePath $appSourceCopJsonFilePath -originalAppSourceCopJsonContent $originalAppSourceCopJson
 }
 catch {
     Write-Host "##vso[task.logissue type=error]Error while updating app.json or pushing changes to Azure DevOps. Error message: $($_.Exception.Message)"

--- a/IncrementVersion/IncrementVersion.ps1
+++ b/IncrementVersion/IncrementVersion.ps1
@@ -100,7 +100,7 @@ try {
     Invoke-GitAddCommit -appFilePath $appFilePath -commitMessage "Updating version to $newAppliedVersion"
 
     # Delete AppSourceCop to skip validation in this build and restore the original AppSourceCop.json
-    Restore-AppSourceCopJson -appSourceCopJsonFilePath $appSourceCopJsonFilePath -originalAppSourceCopJsonContent $originalAppSourceCopJson
+    Restore-AppSourceCopJson -appSourceCopJsonFilePath $appSourceCopJsonFilePath -originalAppSourceCopJsonContent $originalAppSourceCopJson -settings $settings
 }
 catch {
     Write-Host "##vso[task.logissue type=error]Error while updating app.json or pushing changes to Azure DevOps. Error message: $($_.Exception.Message)"

--- a/IncrementVersion/IncrementVersion.ps1
+++ b/IncrementVersion/IncrementVersion.ps1
@@ -88,7 +88,13 @@ try {
     # Set version in app manifests (app.json file)
     $newAppliedVersion = Set-VersionInAppManifests -appFilePath $appFilePath -settings $repositorySettings -newValue $versionNumber
 
+    # Update AppSourceCop json
+    $appSourceCopJsonFilePath = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath "$($settings.appFolders[0])\AppSourceCop.json"
+    Invoke-RestoreUnstagedChanges -appFilePath $appFilePath
+    Update-AppSourceCopJson -appJsonFilePath $appFilePath -appSourceCopJsonFilePath $appSourceCopJsonFilePath -settings $settings
+
     # Commit changes
+    Invoke-GitAdd -appFilePath $appSourceCopJsonFilePath
     Invoke-GitAdd -appFilePath $repositorySettingsPath
     Invoke-GitAddCommit -appFilePath $appFilePath -commitMessage "Updating version to $newAppliedVersion"
 }


### PR DESCRIPTION
This pull request introduces functionality to manage the `AppSourceCop.json` file during the version increment process. Specifically, it adds methods to update and restore the file, ensuring compatibility and validation during builds. The changes include new helper functions and updates to the main script to integrate these functions.

### New functionality for managing `AppSourceCop.json`:

* **Added `Update-AppSourceCopJson` function:** This function updates the `AppSourceCop.json` file with the name, publisher, and version from the `app.json` file, ensuring consistency between the two files. It also checks if `AppSourceCop.json` exists and creates it if necessary. (`IncrementVersion/IncrementVersion.Helper.ps1`, [IncrementVersion/IncrementVersion.Helper.ps1R188-R232](diffhunk://#diff-2dfb423a9df459c528ce85516073acefa54bc70be1d390b61e709df52b48a2c8R188-R232))
* **Added `Restore-AppSourceCopJson` function:** This function restores the original `AppSourceCop.json` file by removing the version property and overwriting the file with the original content. It ensures validation is skipped during the build process. (`IncrementVersion/IncrementVersion.Helper.ps1`, [IncrementVersion/IncrementVersion.Helper.ps1R188-R232](diffhunk://#diff-2dfb423a9df459c528ce85516073acefa54bc70be1d390b61e709df52b48a2c8R188-R232))

### Integration into the version increment workflow:

* **Updated main script to manage `AppSourceCop.json`:** The `Update-AppSourceCopJson` function is called after setting the version in `app.json`, and the `Restore-AppSourceCopJson` function is called after committing changes to skip validation during the build. (`IncrementVersion/IncrementVersion.ps1`, [IncrementVersion/IncrementVersion.ps1R91-R103](diffhunk://#diff-5952a452a4726251380753d176fd762096ee29ec6c429191ae58269cef8572c3R91-R103))