### PR TITLE
Ability to disable recreatePipelineInSetupPipeline

### DIFF
--- a/.Scenarios/SettingsOverview.md
+++ b/.Scenarios/SettingsOverview.md
@@ -246,6 +246,7 @@ Which will ensure that for all repositories named `bcsamples-*` in this organiza
 | <a id="BcContainerHelperVersion"></a>BcContainerHelperVersion | This setting can be set to a specific version (ex. 3.0.8) of BcContainerHelper to force BCDevOps Flows to use this version. **latest** means that BCDevOps Flows will use the latest released version. **preview** means that BCDevOps Flows will use the latest preview version. **dev** means that BCDevOps Flows will use the dev branch of containerhelper. | latest |
 | <a id="failPublishTestsOnFailureToPublishResults"></a>failPublishTestsOnFailureToPublishResults | By default, all projects with enabled tests expect test results. If there are no test results available, the **Publish Test Results** step fails. If you set this setting to false, missing or corrupted tests are considered as successful. | true |
 | <a id="skipAppSourceCopMandatoryAffixesEnforcement"></a>skipAppSourceCopMandatoryAffixesEnforcement | Use this option to skip mandatory enforcement of the Affixes. For example, if you have one PTE project without affixes, you can use this option in combination with custom rule set to suppress enforcement and validation. | false |
+| <a id="recreatePipelineInSetupPipeline"></a>recreatePipelineInSetupPipeline | You must enable this property when you change the workflowSchedule (cron) for a pipeline that already exists in AzureDevOps. | false |
 
 ______________________________________________________________________
 

--- a/ReadSettings/ReadSettings.Helper.ps1
+++ b/ReadSettings/ReadSettings.Helper.ps1
@@ -130,6 +130,7 @@ function ReadSettings {
         "skipAppSourceCopMandatoryAffixesEnforcement" = $false
         "runWith"                                     = "BcContainerHelper"
         "allowPrerelease"                             = $false
+        "recreatePipelineInSetupPipeline"             = $false
     }
 
     # Read settings from files and merge them into the settings object

--- a/SetupPipelines/SetupPipelines.Helper.ps1
+++ b/SetupPipelines/SetupPipelines.Helper.ps1
@@ -54,7 +54,9 @@ function Add-AzureDevOpsPipelineFromYaml {
         [Parameter(Mandatory = $true)]
         [string] $pipelineYamlFileRelativePath,
         [Parameter(Mandatory = $false)]
-        [bool] $skipPipelineFirstRun = $false
+        [bool] $skipPipelineFirstRun = $false,
+        [Parameter(Mandatory = $true)]
+        $settings
     )
 
     OutputDebug "Preparing pipeline '$pipelineName' for branch '$pipelineBranch' with YAML file '$pipelineYamlFileRelativePath' in folder '$pipelineFolder'"
@@ -71,6 +73,10 @@ function Add-AzureDevOpsPipelineFromYaml {
         
     OutputDebug "Existing pipeline details: $existingPipelineDetails"
     if ($existingPipelineDetails.Count -gt 0) {
+        if (-not $settings.recreatePipelineInSetupPipeline) {
+            Write-Host "Pipeline $pipelineName exists. Skipping..."
+            return
+        }
         Write-Host "Pipeline $pipelineName exists. Removing..."
         foreach ($pipeline in $existingPipelineDetails) {
             az pipelines delete `

--- a/SetupPipelines/SetupPipelines.ps1
+++ b/SetupPipelines/SetupPipelines.ps1
@@ -44,6 +44,7 @@ try {
         $pipelineYamlFileRelativePath = "$scriptsFolderName\$($pipelineYamlFilePath.BaseName).yml"
     
         Add-AzureDevOpsPipelineFromYaml `
+            -settings $settings `
             -pipelineName $pipelineName `
             -pipelineFolder $pipelineDevOpsFolderPath `
             -pipelineBranch $settings.pipelineBranch `


### PR DESCRIPTION
This pull request introduces a new setting, `recreatePipelineInSetupPipeline`, to provide better control over pipeline management in Azure DevOps. The changes primarily focus on enabling conditional pipeline recreation based on this setting and updating relevant scripts and documentation.

### New Feature: Conditional Pipeline Recreation

* [`.Scenarios/SettingsOverview.md`](diffhunk://#diff-0a85dd5a72c18c3ad31949b08bf2a17e2756479675c6ad1dd9fe06fd2bef6035R249): Added documentation for the new `recreatePipelineInSetupPipeline` setting, explaining its purpose and default value (`false`).
* [`ReadSettings/ReadSettings.Helper.ps1`](diffhunk://#diff-f68e0b52fd2750401b799b2cf2698a2d3795379fce9ea2ac077e2e6aaf912b06R133): Included `recreatePipelineInSetupPipeline` in the default settings object with a default value of `false`.

### Pipeline Management Enhancements

* `SetupPipelines/SetupPipelines.Helper.ps1`: 
  - Updated `Add-AzureDevOpsPipelineFromYaml` to accept the `settings` parameter, enabling access to the new setting.
  - Implemented conditional logic to skip pipeline recreation if `recreatePipelineInSetupPipeline` is set to `false`.
* [`SetupPipelines/SetupPipelines.ps1`](diffhunk://#diff-bfd3dc115f896c596edf191e2644c36d477af22bd10ecf7cb54f46f3125471aaR47): Passed the `settings` object to `Add-AzureDevOpsPipelineFromYaml` to ensure the new setting is utilized during pipeline setup.