### PR TITLE
Skip MSSymbols for dependencies & Third party symbols for MS dependencies

### DIFF
--- a/.Internal/Nuget.Helper.ps1
+++ b/.Internal/Nuget.Helper.ps1
@@ -50,7 +50,7 @@ function Remove-AllNugetPackageSources() {
     Param()
 
     OutputDebug -Message "Removing all existing NuGet package sources"
-    $sources = Get-PackageSource -ProviderName NuGet -WarningAction SilentlyContinue
+    $sources = Get-PackageSource -ProviderName NuGet -WarningAction SilentlyContinue | Out-Null
     if (!$sources) {
         OutputDebug -Message "No NuGet package sources found"
         return

--- a/.Internal/Nuget.Helper.ps1
+++ b/.Internal/Nuget.Helper.ps1
@@ -49,7 +49,12 @@ function GetNugetPackagePath() {
 function Remove-AllNugetPackageSources() {
     Param()
 
+    OutputDebug -Message "Removing all existing NuGet package sources"
     $sources = Get-PackageSource -ProviderName NuGet -ErrorAction SilentlyContinue
+    if (!$sources) {
+        OutputDebug -Message "No NuGet package sources found"
+        return
+    }
     foreach ($source in $sources) {
         RemoveNugetPackageSource -sourceName $source.Name
     }
@@ -107,7 +112,6 @@ function Get-BCCTrustedNuGetFeeds {
         [switch] $skipSymbolsFeeds
     )
 
-    OutputDebug -Message "Removing all existing NuGet package sources"
     Remove-AllNugetPackageSources
 
     $requiredTrustedNuGetFeeds = @()

--- a/.Internal/Nuget.Helper.ps1
+++ b/.Internal/Nuget.Helper.ps1
@@ -50,13 +50,13 @@ function Remove-AllNugetPackageSources() {
     Param()
 
     OutputDebug -Message "Removing all existing NuGet package sources"
-    $sources = Get-PackageSource -ProviderName NuGet -ErrorAction SilentlyContinue
+    $sources = Get-PackageSource -ProviderName NuGet | Out-Null
     if (!$sources) {
         OutputDebug -Message "No NuGet package sources found"
         return
     }
     foreach ($source in $sources) {
-        RemoveNugetPackageSource -sourceName $source.Name
+        Remove-NugetPackageSource -sourceName $source.Name
     }
 }
 function Add-NugetPackageSource() {
@@ -73,7 +73,7 @@ function Add-NugetPackageSource() {
         OutputDebug -Message "Nuget source $($feed.name) already exists"
     }
 }
-function RemoveNugetPackageSource() {
+function Remove-NugetPackageSource() {
     Param(
         [string] $sourceName
     )

--- a/.Internal/Nuget.Helper.ps1
+++ b/.Internal/Nuget.Helper.ps1
@@ -50,7 +50,7 @@ function Remove-AllNugetPackageSources() {
     Param()
 
     OutputDebug -Message "Removing all existing NuGet package sources"
-    $sources = Get-PackageSource -ProviderName NuGet | Out-Null
+    $sources = Get-PackageSource -ProviderName NuGet -WarningAction SilentlyContinue
     if (!$sources) {
         OutputDebug -Message "No NuGet package sources found"
         return

--- a/Build/WithBCContainerHelper/BuildWithBCContainerHelper.ps1
+++ b/Build/WithBCContainerHelper/BuildWithBCContainerHelper.ps1
@@ -212,9 +212,7 @@ try {
         }
     }
 
-    # Initialize trusted NuGet feeds
-    $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL -trustMicrosoftNuGetFeeds $settings.trustMicrosoftNuGetFeeds -skipSymbolsFeeds
-    if (($trustedNuGetFeeds.Count -gt 0) -and ($runAlPipelineParams.Keys -notcontains 'InstallMissingDependencies')) {
+    if ($runAlPipelineParams.Keys -notcontains 'InstallMissingDependencies') {
         $runAlPipelineParams += @{
             "InstallMissingDependencies" = {
                 Param(

--- a/DeterminePackages/DeterminePackages.Helper.ps1
+++ b/DeterminePackages/DeterminePackages.Helper.ps1
@@ -9,7 +9,6 @@ function Get-DependenciesFromNuGet {
     )
 
     $settings = $settings | Copy-HashTable
-    $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL -trustMicrosoftNuGetFeeds $settings.trustMicrosoftNuGetFeeds
     Write-Host "Checking appDependenciesNuGet and testDependenciesNuGet"
     $getDependencyNuGetPackageParams = @{}
     if ($ENV:AL_ALLOWPRERELEASE) {
@@ -18,6 +17,7 @@ function Get-DependenciesFromNuGet {
         }
     }
     if ($settings.appDependenciesNuGet) {
+        $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL
         $settings.appDependenciesNuGet | ForEach-Object {
             $packageName = $_
             $appFile = Get-BCDevOpsFlowsNuGetPackage -trustedNugetFeeds $trustedNuGetFeeds -packageName $packageName @getDependencyNuGetPackageParams
@@ -32,6 +32,7 @@ function Get-DependenciesFromNuGet {
     }
 
     if ($settings.testDependenciesNuGet) {
+        $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL
         $settings.testDependenciesNuGet | ForEach-Object {
             $packageName = $_
             $appFile = Get-BCDevOpsFlowsNuGetPackage -trustedNugetFeeds $trustedNuGetFeeds -packageName $packageName @getDependencyNuGetPackageParams

--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -13,11 +13,6 @@ try {
     }
 
     $settings = $ENV:AL_SETTINGS | ConvertFrom-Json
-    $TrustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL -trustMicrosoftNuGetFeeds $settings.trustMicrosoftNuGetFeeds
-    foreach ($feed in $TrustedNuGetFeeds) {
-        Add-NugetPackageSource -feed $feed
-    }
-
     $baseRepoFolder = "$ENV:PIPELINE_WORKSPACE\App"
     $baseAppFolder = "$baseRepoFolder\$appFolder"
 
@@ -35,13 +30,13 @@ try {
     if (!(Test-Path $dependenciesPackageCachePath)) {
         New-Item -Path $dependenciesPackageCachePath -ItemType Directory | Out-Null
     }
-    
 
     $artifact = $settings.artifact
     Write-Host "Getting application package $applicationPackage for artifact $artifact"
     
     # Init application/platform parameters
     if ($ENV:AL_RUNWITH -eq "NuGet") {
+        $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -includeMicrosoftNuGetFeeds -trustMicrosoftNuGetFeeds $settings.trustMicrosoftNuGetFeeds
         $parameters = @{
             "trustedNugetFeeds"    = $trustedNuGetFeeds
             "packageName"          = $applicationPackage
@@ -72,6 +67,7 @@ try {
     }
 
     # Init dependency parameters
+    $trustedNuGetFeeds = Get-BCCTrustedNuGetFeeds -fromTrustedNuGetFeeds $ENV:AL_TRUSTEDNUGETFEEDS_INTERNAL
     $parameters = @{
         "trustedNugetFeeds"    = $trustedNuGetFeeds
         "appSymbolsFolder"     = $dependenciesPackageCachePath


### PR DESCRIPTION
This pull request introduces several updates to PowerShell scripts that manage NuGet package sources and dependencies. The changes focus on improving functionality for handling trusted NuGet feeds, simplifying feed management, and ensuring compatibility with Microsoft NuGet feeds. Below is a breakdown of the most important changes.

### Enhancements to NuGet Feed Management:

* Added a new function `Remove-AllNugetPackageSources` to clear all existing NuGet package sources, ensuring a clean slate before adding trusted feeds. (`.Internal/Nuget.Helper.ps1`, [.Internal/Nuget.Helper.ps1R49-R61](diffhunk://#diff-f5b83b9d5d4e940705bb9fc261a8a32d05f0bceb84e3f9a1b5b7d736a9d00e42R49-R61))
* Renamed the `RemoveNugetPackageSource` function to `Remove-NugetPackageSource` for consistency with PowerShell naming conventions. (`.Internal/Nuget.Helper.ps1`, [.Internal/Nuget.Helper.ps1L63-R76](diffhunk://#diff-f5b83b9d5d4e940705bb9fc261a8a32d05f0bceb84e3f9a1b5b7d736a9d00e42L63-R76))

### Updates to Trusted NuGet Feeds Handling:

* Modified `Get-BCCTrustedNuGetFeeds` to include a new optional parameter `includeMicrosoftNuGetFeeds` and added validation to ensure Microsoft NuGet feeds are trusted when required. (`.Internal/Nuget.Helper.ps1`, [.Internal/Nuget.Helper.ps1L111-R132](diffhunk://#diff-f5b83b9d5d4e940705bb9fc261a8a32d05f0bceb84e3f9a1b5b7d736a9d00e42L111-R132))
* Removed the logic for skipping symbol feeds within `Get-BCCTrustedNuGetFeeds`, simplifying the feed filtering process. (`.Internal/Nuget.Helper.ps1`, [.Internal/Nuget.Helper.ps1L121-L123](diffhunk://#diff-f5b83b9d5d4e940705bb9fc261a8a32d05f0bceb84e3f9a1b5b7d736a9d00e42L121-L123))

### Integration with Other Scripts:

* Updated `BuildWithBCContainerHelper.ps1` to remove initialization of trusted NuGet feeds and streamline the parameters for dependency installation. (`Build/WithBCContainerHelper/BuildWithBCContainerHelper.ps1`, [Build/WithBCContainerHelper/BuildWithBCContainerHelper.ps1L215-R215](diffhunk://#diff-3d009ac46a276368e9ae1b5811c942af593479a9d230ce3cc82e4bcaa49154a3L215-R215))
* Adjusted `DeterminePackages.Helper.ps1` to retrieve trusted NuGet feeds only when dependencies are being processed, improving efficiency. (`DeterminePackages/DeterminePackages.Helper.ps1`, [[1]](diffhunk://#diff-5734d6d3c80f04d328270c841f685e32f78bce5086e9108b2d9e68069d456959R20) [[2]](diffhunk://#diff-5734d6d3c80f04d328270c841f685e32f78bce5086e9108b2d9e68069d456959R35)
* Refactored `DetermineNugetPackages.ps1` to use the new feed management logic, including the `includeMicrosoftNuGetFeeds` parameter for compatibility with Microsoft feeds. (`DeterminePackages/ForNuGet/DetermineNugetPackages.ps1`, [[1]](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536L39-R39) [[2]](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536R70)