### PR TITLE
Skip test app dependency if it's the main app

### DIFF
--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -16,10 +16,7 @@ if (!$ENV:AL_NUGETINITIALIZED) {
 
 $settings = $ENV:AL_SETTINGS | ConvertFrom-Json
 $baseRepoFolder = "$ENV:PIPELINE_WORKSPACE\App"
-$baseAppFolder = "$baseRepoFolder\$appFolder"
-
 $artifact = $settings.artifact
-$appJsonContent = Get-Content "$baseAppFolder\app.json" -Encoding UTF8 | ConvertFrom-Json
 
 # Init application/platform parameters
 $isAppJsonArtifact = $artifact.ToLower() -eq "////appjson"


### PR DESCRIPTION
This pull request refactors the `DeterminePackages` script to enhance flexibility and improve handling of app and test dependencies. The most significant changes include switching from folder-based to JSON-based dependency determination, adding error handling for missing test app files, and refining dependency filtering logic.

### Refactoring for JSON-based dependency determination:
* Modified `DeterminePackages/DeterminePackages.ps1` to pass `app.json` content as a parameter to the `DetermineNugetPackages.ps1` script instead of relying on folder paths. This allows more precise handling of app metadata. [[1]](diffhunk://#diff-3cd5445ee72755db5793af22381ad94203afd1c3b294eff47b06129bab8562d3L26-R27) [[2]](diffhunk://#diff-3cd5445ee72755db5793af22381ad94203afd1c3b294eff47b06129bab8562d3L36-R44)
* Updated `DeterminePackages/ForNuGet/DetermineNugetPackages.ps1` to accept `appJsonContent` as a mandatory parameter and removed the `appFolder` parameter.

### Enhanced error handling:
* Added a check in `DeterminePackages/DeterminePackages.ps1` to skip test app package determination if the `app.json` file for the test app is missing, with a clear log message.

### Improved dependency filtering:
* Updated `DeterminePackages/ForNuGet/DetermineNugetPackages.ps1` to skip dependencies matching the main app ID, preventing redundant processing of the main app as a dependency.

### Miscellaneous adjustments:
* Refactored initialization of dependency parameters and ensured proper handling of trusted NuGet feeds. [[1]](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536R21-L41) [[2]](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536R78-R90)