### PR TITLE
Update BCC urls

### DIFF
--- a/.Internal/BCContainerHelper.Helper.ps1
+++ b/.Internal/BCContainerHelper.Helper.ps1
@@ -98,13 +98,13 @@ function GetBcContainerHelperPath([string] $bcContainerHelperVersion) {
                 $tempName = Join-Path $bcContainerHelperRootFolder ([Guid]::NewGuid().ToString())
                 $bcContainerHelperVersion = "preview"
                 Write-Host "Download failed, downloading BcContainerHelper $bcContainerHelperVersion version from Blob Storage"
-                $webclient.DownloadFile("https://bccontainerhelper.blob.core.windows.net/public/$($bcContainerHelperVersion).zip", "$tempName.zip")
+                $webclient.DownloadFile("https://bccontainerhelper-addgd5gzaxf9fneh.b02.azurefd.net/public/$($bcContainerHelperVersion).zip", "$tempName.zip")
             }
         }
         else {
             $tempName = Join-Path $bcContainerHelperRootFolder ([Guid]::NewGuid().ToString())
             Write-Host "Downloading BcContainerHelper $bcContainerHelperVersion version from Blob Storage"
-            $webclient.DownloadFile("https://bccontainerhelper.blob.core.windows.net/public/$($bcContainerHelperVersion).zip", "$tempName.zip")
+            $webclient.DownloadFile("https://bccontainerhelper-addgd5gzaxf9fneh.b02.azurefd.net/public/$($bcContainerHelperVersion).zip", "$tempName.zip")
         }
         Expand-7zipArchive -Path "$tempName.zip" -DestinationPath $tempName
         $bcContainerHelperPath = (Get-Item -Path (Join-Path $tempName "*\BcContainerHelper.ps1")).FullName


### PR DESCRIPTION
This pull request updates the download URLs used in the `GetBcContainerHelperPath` function to point to a new Azure Front Door endpoint. This change ensures that downloads are routed through the updated CDN for improved reliability and performance.

Key change:

* [`.Internal/BCContainerHelper.Helper.ps1`](diffhunk://#diff-e602c92abfb943c8d8b1de2014788713e3a663ae121d1eca5c1268e09485de49L101-R107): Updated the `DownloadFile` method to use the new Azure Front Door URL (`https://bccontainerhelper-addgd5gzaxf9fneh.b02.azurefd.net`) instead of the previous Blob Storage URL for downloading BcContainerHelper versions.