### PR TITLE
Add mutex when downloading nuget tools

### DIFF
--- a/.Internal/BCContainerHelper.Helper.ps1
+++ b/.Internal/BCContainerHelper.Helper.ps1
@@ -136,6 +136,7 @@ function GetBcContainerHelperPath([string] $bcContainerHelperVersion) {
             }
             finally {
                 $buildMutex.ReleaseMutex()
+                $buildMutex.Close()
             }
             $bcContainerHelperPath = Join-Path $cacheFolder "BcContainerHelper/BcContainerHelper.ps1"
         }

--- a/.Internal/Nuget.Helper.ps1
+++ b/.Internal/Nuget.Helper.ps1
@@ -47,6 +47,7 @@ function DownloadNugetPackage() {
     }
     finally {
         $buildMutex.ReleaseMutex()
+        $buildMutex.Close()
     }
     return $nugetPackagePath
 }

--- a/.Internal/Nuget.Helper.ps1
+++ b/.Internal/Nuget.Helper.ps1
@@ -9,25 +9,44 @@ function DownloadNugetPackage() {
 
     $nugetPackagePath = GetNugetPackagePath -packageName $packageName -packageVersion $packageVersion
     OutputDebug -Message "Using Nuget package path: $nugetPackagePath"
-    if (-not (Test-Path -Path $nugetPackagePath)) {
-        $nugetUrl = "https://www.nuget.org/api/v2/package/$packageName/$packageVersion"
 
-        Write-Host "Downloading Nuget package $packageName $packageVersion from $nugetUrl..."
-        New-Item -ItemType Directory -Path $nugetPackagePath | Out-Null
-        OutputDebug -Message "Downloading Nuget package $nugetUrl to $nugetPackagePath/$packageName.$packageVersion.zip"
-        Invoke-WebRequest -Uri $nugetUrl -OutFile "$nugetPackagePath/$packageName.$packageVersion.zip"
-
-        # Unzip the package
+    # To avoid two agents on the same machine downloading the same version at the same time, use a mutex
+    $buildMutexName = "Download$($packageName)-version$($packageVersion)"
+    $buildMutex = New-Object System.Threading.Mutex($false, $buildMutexName)
+    try {
         try {
-            Expand-Archive -Path "$nugetPackagePath/$packageName.$packageVersion.zip" -DestinationPath "$nugetPackagePath" -Force
+            if (!$buildMutex.WaitOne(1000)) {
+                Write-Host "Waiting for other process loading $packageName ($packageVersion)"
+                $buildMutex.WaitOne() | Out-Null
+                Write-Host "Other process completed loading $packageName ($packageVersion)"
+            }
         }
-        catch {
-            # Fallback for any compatibility issues
-            Add-Type -AssemblyName System.IO.Compression.FileSystem
-            [System.IO.Compression.ZipFile]::ExtractToDirectory("$nugetPackagePath/$packageName.$packageVersion.zip", "$nugetPackagePath")
+        catch [System.Threading.AbandonedMutexException] {
+            Write-Host "Other process terminated abnormally"
         }
-        # Remove the zip file
-        Remove-Item -Path "$nugetPackagePath/$packageName.$packageVersion.zip"
+        if (-not (Test-Path -Path $nugetPackagePath)) {
+            $nugetUrl = "https://www.nuget.org/api/v2/package/$packageName/$packageVersion"
+
+            Write-Host "Downloading Nuget package $packageName $packageVersion from $nugetUrl..."
+            New-Item -ItemType Directory -Path $nugetPackagePath | Out-Null
+            OutputDebug -Message "Downloading Nuget package $nugetUrl to $nugetPackagePath/$packageName.$packageVersion.zip"
+            Invoke-WebRequest -Uri $nugetUrl -OutFile "$nugetPackagePath/$packageName.$packageVersion.zip"
+
+            # Unzip the package
+            try {
+                Expand-Archive -Path "$nugetPackagePath/$packageName.$packageVersion.zip" -DestinationPath "$nugetPackagePath" -Force
+            }
+            catch {
+                # Fallback for any compatibility issues
+                Add-Type -AssemblyName System.IO.Compression.FileSystem
+                [System.IO.Compression.ZipFile]::ExtractToDirectory("$nugetPackagePath/$packageName.$packageVersion.zip", "$nugetPackagePath")
+            }
+            # Remove the zip file
+            Remove-Item -Path "$nugetPackagePath/$packageName.$packageVersion.zip"
+        }
+    }
+    finally {
+        $buildMutex.ReleaseMutex()
     }
     return $nugetPackagePath
 }


### PR DESCRIPTION
This pull request enhances the `DownloadNugetPackage` function in `.Internal/Nuget.Helper.ps1` to improve concurrency safety when multiple agents on the same machine attempt to download the same NuGet package version simultaneously. The changes introduce a mutex mechanism to prevent race conditions and ensure orderly access.

Concurrency safety improvements:

* Added a mutex (`$buildMutex`) to the `DownloadNugetPackage` function to prevent simultaneous downloads of the same package version by multiple processes. The mutex is named dynamically based on the package name and version.
* Implemented logic to handle mutex acquisition, including waiting for other processes and handling abnormal termination of other processes using `AbandonedMutexException`.
* Ensured the mutex is released in a `finally` block to guarantee proper cleanup even if an error occurs during the download process.