### PR TITLE
SetupPipelines with Repo as folder - remove organization in Hybrid Deployments

### DIFF
--- a/SetupPipelines/SetupPipelines.Helper.ps1
+++ b/SetupPipelines/SetupPipelines.Helper.ps1
@@ -14,7 +14,12 @@ function Get-PipelineDevOpsFolderPath {
 
     switch ($settings.pipelineFolderStructure) {
         'Repository' {
-            $pipelineFolderPath = $ENV:BUILD_REPOSITORY_NAME
+            $pipelineFolderPath = if ($ENV:BUILD_REPOSITORY_NAME -like '*/*') {
+                $ENV:BUILD_REPOSITORY_NAME.Split('/')[-1]
+            }
+            else {
+                $ENV:BUILD_REPOSITORY_NAME
+            }
         }
         'Pipeline' {
             $pipelineFolderPath = $ENV:BUILD_DEFINITIONNAME


### PR DESCRIPTION
This pull request updates the `Get-PipelineDevOpsFolderPath` function in the `SetupPipelines.Helper.ps1` file to enhance the handling of repository names in pipeline folder paths.

Enhancements to repository name handling:

* [`SetupPipelines/SetupPipelines.Helper.ps1`](diffhunk://#diff-0fa1165ed5b2e1ae710ba55c0f16db435870f60f1d3dbf50d821fbeee7de81c7L17-R22): Modified the logic for determining `$pipelineFolderPath` when the `pipelineFolderStructure` is set to 'Repository'. If the repository name contains a '/' character, the function now extracts the last segment of the name using `.Split('/')[-1]`. Otherwise, it uses the repository name as-is.