### PR TITLE
Use correct package name for w1

### DIFF
--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -30,7 +30,7 @@ if ($isTestApp) {
 }
 else {
     $applicationPackage = "Microsoft.Application.symbols"
-    if ($settings.country) {
+    if ($settings.country -and $settings.country.ToLower() -ne "w1") {
         $applicationPackage = "Microsoft.Application.$($settings.country.ToUpper()).symbols"
     }
     Write-Host "Getting application package $applicationPackage for artifact $artifact"


### PR DESCRIPTION
This pull request includes a small but important change to the `DetermineNugetPackages.ps1` script. The conditional logic for determining the `applicationPackage` has been updated to exclude cases where the country is "w1" (case-insensitive).

* [`DetermineNugetPackages.ps1`](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536L33-R33): Updated the condition in the `if ($settings.country)` block to check if `$settings.country` is not "w1" (case-insensitive) before modifying the `applicationPackage` value.