### PR TITLE
Remove unsupported characters from app file

### DIFF
--- a/.Internal/FindDependencies.Helper.ps1
+++ b/.Internal/FindDependencies.Helper.ps1
@@ -36,7 +36,7 @@ function Get-AppSourceFileLocation {
         $appFile
     )
 
-    return (Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath ".output") + '/' + (Get-AppFileName -publisher $appFile.publisher -name $appFile.name -version $appFile.version);
+    return (Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath ".output") + '\' + (Get-AppFileName -publisher $appFile.publisher -name $appFile.name -version $appFile.version);
 }
 function Get-AppFileName {
     [CmdletBinding()]
@@ -46,5 +46,7 @@ function Get-AppFileName {
         [string]$version
     )
 
-    return $publisher + '_' + $name + '_' + $version + '.app';
+    $appFileName = $sanitizedPublisher + '_' + $sanitizedName + '_' + $sanitizedVersion + '.app'
+    $sanitizedAppFileName = $appFileName -replace '[\\/:*?"<>|]', ''
+    return $sanitizedAppFileName
 }


### PR DESCRIPTION
This pull request includes updates to the `.Internal/FindDependencies.Helper.ps1` script to improve file path handling and sanitize file names. The key changes ensure compatibility with different file systems and prevent invalid characters in generated file names.

Improvements to file path handling:

* Updated `Get-AppSourceFileLocation` to use a backslash (`This pull request includes updates to the `.Internal/FindDependencies.Helper.ps1` script to improve file path handling and sanitize file names. The key changes ensure compatibility with different file systems and prevent invalid characters in generated file names.

Improvements to file path handling:

) instead of a forward slash (`/`) when joining paths, ensuring compatibility with Windows file systems.

File name sanitization:

* Modified `Get-AppFileName` to sanitize the generated file name by removing invalid characters (`[\/:*?"<>|]`) to ensure compatibility across file systems.