### PR TITLE
Remove unsupported characters

### DIFF
--- a/SetupPipelines/SetupPipelines.Helper.ps1
+++ b/SetupPipelines/SetupPipelines.Helper.ps1
@@ -99,6 +99,15 @@ function Add-AzureDevOpsPipelineFromYaml {
         }
     }
    
+    # Remove unsupported characters from pipeline folder and name
+    $pipelineFolder = $pipelineFolder -replace '^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$', ''
+    $pipelineFolder = $pipelineFolder -replace '[^a-zA-Z0-9\\\-_]', ''
+    $pipelineFolder = $pipelineFolder -replace '^[\-_]+|[\-_]+$', ''
+
+    $pipelineName = $pipelineName -replace '^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$', ''
+    $pipelineName = $pipelineName -replace '[^a-zA-Z0-9\-_]', ''
+    $pipelineName = $pipelineName -replace '^[\-_]+|[\-_]+$', ''
+
     Write-Host "Creating pipeline $pipelineName in folder $pipelineFolder for repository $($ENV:BUILD_REPOSITORY_PROVIDER) $($ENV:BUILD_REPOSITORY_NAME)"
     
     if ($ENV:BUILD_REPOSITORY_PROVIDER.ToLower() -eq "github") {


### PR DESCRIPTION
This pull request adds input sanitization to the `Add-AzureDevOpsPipelineFromYaml` function in the `SetupPipelines.Helper.ps1` file. The changes ensure that unsupported characters are removed from pipeline folder and name values.

### Input sanitization for pipeline folder and name:
* Added regex-based sanitization to remove unsupported characters from `$pipelineFolder` and `$pipelineName`, ensuring they only contain alphanumeric characters, backslashes, hyphens, or underscores. Leading and trailing unsupported characters are also stripped. (`[SetupPipelines/SetupPipelines.Helper.ps1R102-R110](diffhunk://#diff-0fa1165ed5b2e1ae710ba55c0f16db435870f60f1d3dbf50d821fbeee7de81c7R102-R110)`)