### PR TITLE
Specify app/test delivery targets in settings

### DIFF
--- a/.Scenarios/SettingsOverview.md
+++ b/.Scenarios/SettingsOverview.md
@@ -117,6 +117,8 @@ Table below shows what functionality is currently supported in BCDevOps Flows by
 | <a id="writableFolderPath"></a>writableFolderPath | Specifies a folder used by pipelines to store/cache build configuration, nuget packages or to build local app file library. Accounts configured to run DevOps agents must have write permissions to this folder. | [ ] |
 | <a id="artifactUrlCacheKeepHours"></a>artifactUrlCacheKeepHours | Specifies how long the artifact url cache is valid (in hours). If this value is different from 0, all requests for the same artifact (for example "**/Sandbox//au/latest**" (which is the same as "**////latest**" if you have country in settings set to AU)) will skip calling BcContainerHelper and will use the same artifactUrl. | 6 |
 | <a id="hybridDeploymentGitHubRepoSCId"></a>hybridDeploymentGitHubRepoSCId | Specifies the ID of the Service Connection that links the Azure DevOps with GitHub where the repository is located. This value is mandatory for hybrid deployments and ignored for standard, Azure DevOps only, deployments. |  |
+| <a id="appDeliverToType"></a>appDeliverToType | Specifies the name of the delivery target for app files to package repository. | Apps |
+| <a id="testDeliverToType"></a>testDeliverToType | Specifies the name of the delivery target for test files to package repository. | Tests |
 
 ## AppSource specific basic project settings
 

--- a/ReadSettings/ReadSettings.Helper.ps1
+++ b/ReadSettings/ReadSettings.Helper.ps1
@@ -137,7 +137,9 @@ function ReadSettings {
         "runWith"                                     = "BcContainerHelper"
         "allowPrerelease"                             = $false
         "recreatePipelineInSetupPipeline"             = $false
-        "hybridDeploymentGitHubRepoSCId"            = ""
+        "hybridDeploymentGitHubRepoSCId"              = ""
+        "appDeliverToType"                            = "Apps"
+        "testDeliverToType"                           = "Tests"
     }
 
     # Read settings from files and merge them into the settings object


### PR DESCRIPTION
This pull request introduces new configuration options for specifying delivery target types for app and test files, along with corresponding updates to the delivery logic in the PowerShell scripts. The changes enhance flexibility and error handling in the delivery process.

### New Configuration Options:
* [`.Scenarios/SettingsOverview.md`](diffhunk://#diff-0a85dd5a72c18c3ad31949b08bf2a17e2756479675c6ad1dd9fe06fd2bef6035R120-R121): Added two new settings, `appDeliverToType` and `testDeliverToType`, to specify the delivery target names for app and test files in the package repository.
* [`ReadSettings/ReadSettings.Helper.ps1`](diffhunk://#diff-f68e0b52fd2750401b799b2cf2698a2d3795379fce9ea2ac077e2e6aaf912b06R141-R142): Updated the default settings to include `appDeliverToType` (default: "Apps") and `testDeliverToType` (default: "Tests").

### Delivery Logic Enhancements:
* [`DeliverAppFile/DeliverAppFile.ps1`](diffhunk://#diff-ba3c1d327ba0d4d84c89b72d9f88beaa215c4109f6966f35a6aa5141cdfd3b10R20-R52): Modified the delivery logic to check if the `appDeliverToType` or `testDeliverToType` settings are specified and non-empty. If not, the delivery process for the corresponding type is skipped, with a message logged to the console.