### PR TITLE
generateCountryPreprocessorSymbols

### DIFF
--- a/.Scenarios/SettingsOverview.md
+++ b/.Scenarios/SettingsOverview.md
@@ -176,6 +176,7 @@ Table below shows what functionality is currently supported in BCDevOps Flows by
 | <a id="includeSourceInSymbolFile"></a>includeSourceInSymbolFile | Specifies new value for includeSourceInSymbolFile resource exposure policy. If the setting is not configured, the existing value defined in the app.json is used. overrideResourceExposurePolicy must be enabled in order to use configured value. |  |
 | <a id="applyToDevExtension"></a>applyToDevExtension | Specifies new value for applyToDevExtension resource exposure policy. If the setting is not configured, the existing value defined in the app.json is used. overrideResourceExposurePolicy must be enabled in order to use configured value. |  |
 | <a id="trustMicrosoftNuGetFeeds"></a>trustMicrosoftNuGetFeeds | Unless this setting is set to false, BC DevOps Flows will trust the NuGet feeds provided by Microsoft. The feeds provided by Microsoft contains all Microsoft apps, all Microsoft symbols and symbols for all AppSource apps. | true |
+| <a id="generateCountryPreprocessorSymbols"></a>generateCountryPreprocessorSymbols | If enabled, BC DevOps Flows automatically generates preprocessor symbol COUNTRY_XX where XX is the localization country code of the container. | false |
 
 
 ## AppSource specific advanced settings

--- a/ReadSettings/ReadSettings.Helper.ps1
+++ b/ReadSettings/ReadSettings.Helper.ps1
@@ -141,6 +141,7 @@ function ReadSettings {
         "appDeliverToType"                            = "Apps"
         "testDeliverToType"                           = "Tests"
         "updateAppSourceCop"                          = $false
+        "generateCountryPreprocessorSymbols"          = $false
     }
 
     # Read settings from files and merge them into the settings object


### PR DESCRIPTION
This pull request introduces support for automatically generating country-specific preprocessor symbols in BC DevOps Flows. The main change is the addition of a new setting, `generateCountryPreprocessorSymbols`, which, when enabled, will create preprocessor symbols based on the localization country codes specified in the settings. The changes also include improvements to how preprocessor symbols are handled and documented.

**Country preprocessor symbol generation:**

* Added a new setting, `generateCountryPreprocessorSymbols`, to the default settings and documentation, allowing users to enable automatic generation of preprocessor symbols in the format `COUNTRY_XX` (where `XX` is the country code). [[1]](diffhunk://#diff-f68e0b52fd2750401b799b2cf2698a2d3795379fce9ea2ac077e2e6aaf912b06R144) [[2]](diffhunk://#diff-0a85dd5a72c18c3ad31949b08bf2a17e2756479675c6ad1dd9fe06fd2bef6035R179)
* Updated the `Get-PreprocessorSymbols` function in `Build.Helper.ps1` to generate and add country-specific preprocessor symbols based on the `country` and `additionalCountries` settings when `generateCountryPreprocessorSymbols` is enabled.

**Preprocessor symbol handling improvements:**

* Improved handling of preprocessor symbols by trimming whitespace and ensuring symbols from both `app.json` and settings are correctly merged and deduplicated.
* Enhanced the removal of ignored preprocessor symbols by trimming whitespace and suppressing output when removing symbols.

**Documentation updates:**

* Updated `.Scenarios/SettingsOverview.md` to document the new `generateCountryPreprocessorSymbols` setting and its default value.