### PR TITLE
Do not install current app if specified in setup

### DIFF
--- a/DeterminePackages/DeterminePackages.ps1
+++ b/DeterminePackages/DeterminePackages.ps1
@@ -13,8 +13,9 @@ try {
 
     # Update settings from app configuration
     $settings = $ENV:AL_SETTINGS | ConvertFrom-Json | ConvertTo-HashTable
+    $appJsonContentApp = Get-Content "$ENV:PIPELINE_WORKSPACE\App\App\app.json" -Encoding UTF8 | ConvertFrom-Json
     $settings = Update-CustomCodeCops -settings $settings -runWith $runWith
-    $settings = Get-DependenciesFromNuGet -settings $settings
+    $settings = Get-DependenciesFromNuGet -settings $settings -appJsonContent $appJsonContentApp
     $settings = Get-PreviousReleaseFromNuGet -settings $settings
 
     # Set output variables
@@ -23,7 +24,6 @@ try {
     OutputDebug -Message "Set environment variable AL_SETTINGS to ($ENV:AL_SETTINGS)"
 
     # Determine packages
-    $appJsonContentApp = Get-Content "$ENV:PIPELINE_WORKSPACE\App\App\app.json" -Encoding UTF8 | ConvertFrom-Json
     . (Join-Path -Path $PSScriptRoot -ChildPath "ForNuGet\DetermineNugetPackages.ps1" -Resolve) -appJsonContent $appJsonContentApp
 
     if ($runWith -eq 'nuget') {


### PR DESCRIPTION
This pull request updates the NuGet package dependency resolution logic in the `DeterminePackages` scripts to ensure the current app's package is not redundantly added as a dependency. The changes introduce a new parameter for passing the current app's metadata and update function signatures and calls accordingly.

Dependency resolution improvements:

* Updated `Get-NuGetPackagesAndAddToSettings` to accept the current app's metadata via a new mandatory `appJsonContent` parameter, and skip adding a package if its name matches the current app's ID.
* Updated all invocations of `Get-NuGetPackagesAndAddToSettings` in `Get-DependenciesFromNuGet` to pass the `appJsonContentApp` parameter, ensuring consistent behavior across dependency types.
* Modified the `Get-DependenciesFromNuGet` function to require and accept the `appJsonContent` parameter, propagating the app metadata throughout the dependency resolution process.

Script integration updates:

* In `DeterminePackages.ps1`, loaded the current app's `app.json` into `appJsonContentApp` and passed it to `Get-DependenciesFromNuGet` to enable the new logic.
* Removed redundant loading of `appJsonContentApp` in a later section of `DeterminePackages.ps1` to avoid unnecessary file reads.