### PR TITLE
Custom get dependency version filter

### DIFF
--- a/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
+++ b/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
@@ -270,14 +270,19 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
                     }
                     if ($downloadIt) {
                         . (Join-Path -Path $PSScriptRoot -ChildPath "..\..\CustomLogic\GetDependencyVersionFilter.ps1" -Resolve)
-                        $dependencyVersion = GetDependencyVersionFilter -appJson $originalAppJsonContent -dependency $dependency
-                        if ($dependencyVersion -ne '') {
-                            OutputDebug -Message "Using custom dependency version filter '$dependencyVersion' for dependency $($dependency.name)."
+                        $dependencyJsonContent = [PSCustomObject]@{
+                            "publisher" = $dependencyPublisher
+                            "name"      = $matches[2]
+                            "version"   = $dependencyVersion
                         }
-                        elseif ($dependency.publisher -ne "Microsoft") {
+                        $dependencyVersion = GetDependencyVersionFilter -appJson $originalAppJsonContent -dependency $dependencyJsonContent
+                        if ($dependencyVersion -ne '') {
+                            OutputDebug -Message "Using custom dependency version filter '$dependencyVersion' for dependency $($dependencyJsonContent.name)."
+                        }
+                        elseif ($dependencyJsonContent.publisher -ne "Microsoft") {
                             # For all other use cases, we use the version specified in the dependency (or newer).
-                            $dependencyVersion = "[$($dependency.version),)"
-                            OutputDebug -Message "Using dependency version filter '$dependencyVersion' for dependency $($dependency.name)."
+                            $dependencyVersion = "[$($dependencyJsonContent.version),)"
+                            OutputDebug -Message "Using dependencyJsonContent version filter '$dependencyVersion' for dependency $($dependencyJsonContent.name)."
                         }
                         $returnValue += Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $dependencyId -version $dependencyVersion -originalAppJsonContent $originalAppJsonContent -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps + $returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
                     }

--- a/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
+++ b/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
@@ -275,9 +275,10 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
                             "name"      = $matches[2]
                             "version"   = $dependencyVersion
                         }
-                        $dependencyVersion = GetDependencyVersionFilter -appJson $originalAppJsonContent -dependency $dependencyJsonContent
-                        if ($dependencyVersion -ne '') {
-                            OutputDebug -Message "Using custom dependency version filter '$dependencyVersion' for dependency $($dependencyJsonContent.name)."
+                        $customDependencyVersion = GetDependencyVersionFilter -appJson $originalAppJsonContent -dependency $dependencyJsonContent
+                        if ($customDependencyVersion -ne '') {
+                            OutputDebug -Message "Using custom dependency version filter '$customDependencyVersion' for dependency $($dependencyJsonContent.name)."
+                            $dependencyVersion = $customDependencyVersion
                         }
                         elseif ($dependencyJsonContent.publisher -ne "Microsoft") {
                             # For all other use cases, we use the version specified in the dependency (or newer).

--- a/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
+++ b/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
@@ -283,7 +283,7 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
                         elseif ($dependencyJsonContent.publisher -ne "Microsoft") {
                             # For all other use cases, we use the version specified in the dependency (or newer).
                             $dependencyVersion = "[$($dependencyJsonContent.version),)"
-                            OutputDebug -Message "Using dependencyJsonContent version filter '$dependencyVersion' for dependency $($dependencyJsonContent.name)."
+                            OutputDebug -Message "Using dependency version filter '$dependencyVersion' for dependency $($dependencyJsonContent.name)."
                         }
                         $returnValue += Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $dependencyId -version $dependencyVersion -originalAppJsonContent $originalAppJsonContent -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps + $returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
                     }

--- a/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
+++ b/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
@@ -72,7 +72,7 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
         [string] $downloadDependencies = 'allButApplication',
         [switch] $allowPrerelease,
         [switch] $checkLocalVersion,
-        [string] $originalAppPublisher
+        [string] $originalAppJsonContent
     )
 
     try {
@@ -98,12 +98,12 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
                     $checkPackageName = "$publisher.$name$countryPart$symbolsPart$appIdPart"
                 }
                 if ($checkPackageName -and $checkPackageName -ne $packageName) {
-                    $downloadedPackages = Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $checkPackageName -version $version -originalAppPublisher $originalAppPublisher -folder $folder -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps $installedApps -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease
+                    $downloadedPackages = Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $checkPackageName -version $version -originalAppJsonContent $originalAppJsonContent -folder $folder -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps $installedApps -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease
                     if ($downloadedPackages) {
                         return $downloadedPackages
                     }
                 }
-                return Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -originalAppPublisher $originalAppPublisher -folder $folder -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps $installedApps -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease
+                return Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -originalAppJsonContent $originalAppJsonContent -folder $folder -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps $installedApps -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease
             }
         }
         Write-Host "Looking for NuGet package $packageName version $version ($select match)"
@@ -270,7 +270,7 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
                     }
                     if ($downloadIt) {
                         . (Join-Path -Path $PSScriptRoot -ChildPath "..\..\CustomLogic\GetDependencyVersionFilter.ps1" -Resolve)
-                        $dependencyVersion = GetDependencyVersionFilter -appJson $appJsonContent -dependency $dependency
+                        $dependencyVersion = GetDependencyVersionFilter -appJson $originalAppJsonContent -dependency $dependency
                         if ($dependencyVersion -ne '') {
                             OutputDebug -Message "Using custom dependency version filter '$dependencyVersion' for dependency $($dependency.name)."
                         }
@@ -279,7 +279,7 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
                             $dependencyVersion = "[$($dependency.version),)"
                             OutputDebug -Message "Using dependency version filter '$dependencyVersion' for dependency $($dependency.name)."
                         }
-                        $returnValue += Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $dependencyId -version $dependencyVersion -originalAppPublisher $originalAppPublisher -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps + $returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
+                        $returnValue += Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $dependencyId -version $dependencyVersion -originalAppJsonContent $originalAppJsonContent -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps + $returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
                     }
                 }
                 if ($dependenciesErr) {

--- a/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
+++ b/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
@@ -72,7 +72,7 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
         [string] $downloadDependencies = 'allButApplication',
         [switch] $allowPrerelease,
         [switch] $checkLocalVersion,
-        [string] $originalAppJsonContent
+        [PSCustomObject] $originalAppJsonContent
     )
 
     try {

--- a/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
+++ b/.Internal/NuGet/Get-BCDevOpsFlowsNuGetPackageToFolder.ps1
@@ -71,7 +71,8 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
         [ValidateSet('all', 'own', 'Microsoft', 'allButMicrosoft', 'allButApplication', 'allButPlatform', 'none')]
         [string] $downloadDependencies = 'allButApplication',
         [switch] $allowPrerelease,
-        [switch] $checkLocalVersion
+        [switch] $checkLocalVersion,
+        [string] $originalAppPublisher
     )
 
     try {
@@ -97,12 +98,12 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
                     $checkPackageName = "$publisher.$name$countryPart$symbolsPart$appIdPart"
                 }
                 if ($checkPackageName -and $checkPackageName -ne $packageName) {
-                    $downloadedPackages = Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $checkPackageName -version $version -folder $folder -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps $installedApps -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease
+                    $downloadedPackages = Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $checkPackageName -version $version -originalAppPublisher $originalAppPublisher -folder $folder -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps $installedApps -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease
                     if ($downloadedPackages) {
                         return $downloadedPackages
                     }
                 }
-                return Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -folder $folder -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps $installedApps -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease
+                return Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -originalAppPublisher $originalAppPublisher -folder $folder -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps $installedApps -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease
             }
         }
         Write-Host "Looking for NuGet package $packageName version $version ($select match)"
@@ -268,11 +269,17 @@ Function Get-BCDevOpsFlowsNuGetPackageToFolder {
                         }
                     }
                     if ($downloadIt) {
-                        if ($dependencyVersion.StartsWith('[') -and $select -eq 'Exact') {
-                            # Downloading Microsoft packages for a specific version
-                            $dependencyVersion = $version
+                        . (Join-Path -Path $PSScriptRoot -ChildPath "..\..\CustomLogic\GetDependencyVersionFilter.ps1" -Resolve)
+                        $dependencyVersion = GetDependencyVersionFilter -appJson $appJsonContent -dependency $dependency
+                        if ($dependencyVersion -ne '') {
+                            OutputDebug -Message "Using custom dependency version filter '$dependencyVersion' for dependency $($dependency.name)."
                         }
-                        $returnValue += Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $dependencyId -version $dependencyVersion -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps + $returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
+                        elseif ($dependency.publisher -ne "Microsoft") {
+                            # For all other use cases, we use the version specified in the dependency (or newer).
+                            $dependencyVersion = "[$($dependency.version),)"
+                            OutputDebug -Message "Using dependency version filter '$dependencyVersion' for dependency $($dependency.name)."
+                        }
+                        $returnValue += Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $dependencyId -version $dependencyVersion -originalAppPublisher $originalAppPublisher -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps + $returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
                     }
                 }
                 if ($dependenciesErr) {

--- a/.Internal/NuGet/Publish-BCDevOpsFlowsNuGetPackageToContainer.ps1
+++ b/.Internal/NuGet/Publish-BCDevOpsFlowsNuGetPackageToContainer.ps1
@@ -55,7 +55,8 @@ Function Publish-BCDevOpsFlowsNuGetPackageToContainer {
         [string] $appSymbolsFolder = "",
         [string] $copyInstalledAppsToFolder = "",
         [switch] $allowPrerelease,
-        [switch] $skipVerification
+        [switch] $skipVerification,
+        [string] $originalAppPublisher
     )
 
     if ($containerName -eq "" -and (!($bcAuthContext -and $environment))) {
@@ -83,7 +84,7 @@ Function Publish-BCDevOpsFlowsNuGetPackageToContainer {
         else {
             Write-Host "Prereleased packages are not allowed"
         }
-        if (Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -appSymbolsFolder $tmpFolder -installedApps $installedApps -installedPlatform $installedPlatform -installedCountry $installedCountry -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease ) {
+        if (Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -originalAppPublisher $originalAppPublisher -appSymbolsFolder $tmpFolder -installedApps $installedApps -installedPlatform $installedPlatform -installedCountry $installedCountry -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease ) {
             $appFiles = Get-Item -Path (Join-Path $tmpFolder '*.app') | ForEach-Object {
                 if ($appSymbolsFolder) {
                     Copy-Item -Path $_.FullName -Destination $appSymbolsFolder -Force

--- a/.Internal/NuGet/Publish-BCDevOpsFlowsNuGetPackageToContainer.ps1
+++ b/.Internal/NuGet/Publish-BCDevOpsFlowsNuGetPackageToContainer.ps1
@@ -56,7 +56,7 @@ Function Publish-BCDevOpsFlowsNuGetPackageToContainer {
         [string] $copyInstalledAppsToFolder = "",
         [switch] $allowPrerelease,
         [switch] $skipVerification,
-        [string] $originalAppPublisher
+        [string] $originalAppJsonContent
     )
 
     if ($containerName -eq "" -and (!($bcAuthContext -and $environment))) {
@@ -84,7 +84,7 @@ Function Publish-BCDevOpsFlowsNuGetPackageToContainer {
         else {
             Write-Host "Prereleased packages are not allowed"
         }
-        if (Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -originalAppPublisher $originalAppPublisher -appSymbolsFolder $tmpFolder -installedApps $installedApps -installedPlatform $installedPlatform -installedCountry $installedCountry -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease ) {
+        if (Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -originalAppJsonContent $originalAppJsonContent -appSymbolsFolder $tmpFolder -installedApps $installedApps -installedPlatform $installedPlatform -installedCountry $installedCountry -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease ) {
             $appFiles = Get-Item -Path (Join-Path $tmpFolder '*.app') | ForEach-Object {
                 if ($appSymbolsFolder) {
                     Copy-Item -Path $_.FullName -Destination $appSymbolsFolder -Force

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -5,16 +5,5 @@ function GetDependencyVersionFilter {
         [Parameter(Mandatory = $true)]
         [PSCustomObject] $dependency
     )
-    if ($dependency.publisher.Replace(' ', '') -eq 'Microsoft') {
-        Write-Host "Dependency $($dependency.name) is from Microsoft, no version filter applied."
-        return ""
-    }
-    if ($appJson.publisher.Replace(' ', '') -ne $dependency.publisher.Replace(' ', '')) {
-        Write-Host "Dependency $($dependency.name) is from different publisher ($($dependency.publisher)) than the main app ($($appJson.publisher)), using exact version match."
-        return "[$($dependency.version)]"
-    }
-    $versionParts = $appJson.application.Split('.')
-    $versionParts[1] = ([int]$versionParts[1] + 1).ToString().PadLeft(2, '0')
-    Write-Host "Dependency $($dependency.name) is from the same publisher ($($dependency.publisher)) as the main app ($($appJson.publisher)), using version range [$($dependency.version),$($versionParts[0])$($versionParts[1]).0.0.0)."
-    return "[$($dependency.version),$($versionParts[0])$($versionParts[1]).0.0.0)"
+    return ""
 }

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -1,6 +1,8 @@
 function GetDependencyVersionFilter {
     Param(
+        [Parameter(Mandatory = $true)]
         [PSCustomObject] $appJson,
+        [Parameter(Mandatory = $true)]
         [PSCustomObject] $dependency
     )
     if ($appJson.publisher -ne $dependency.publisher) {

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -10,5 +10,5 @@ function GetDependencyVersionFilter {
     }
     $versionParts = $appJson.application.Split('.')
     $versionParts[1] = ([int]$versionParts[1] + 1).ToString()
-    return "[$($dependency.version),$($versionParts[0]).$($versionParts[1]).0.0)"
+    return "[$($dependency.version),$($versionParts[0])$($versionParts[1]).0.0.0)"
 }

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -3,5 +3,10 @@ function GetDependencyVersionFilter {
         [PSCustomObject] $appJson,
         [PSCustomObject] $dependency
     )
-    return ''
+    if ($appJson.publisher -ne $dependency.publisher) {
+        return "" # Use standard logic
+    }
+    $versionParts = $appJson.application.Split('.')
+    $versionParts[1] = ([int]$versionParts[1] + 1).ToString()
+    return "[$($dependency.version),$($versionParts[0]).$($versionParts[1]).0.0)"
 }

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -1,0 +1,7 @@
+function GetDependencyVersionFilter {
+    Param(
+        [PSCustomObject] $appJson,
+        [PSCustomObject] $dependency
+    )
+    return ''
+}

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -5,11 +5,11 @@ function GetDependencyVersionFilter {
         [Parameter(Mandatory = $true)]
         [PSCustomObject] $dependency
     )
-    if ($dependency.publisher -eq 'Microsoft') {
+    if ($dependency.publisher.Replace(' ', '') -eq 'Microsoft') {
         Write-Host "Dependency $($dependency.name) is from Microsoft, no version filter applied."
         return ""
     }
-    if ($appJson.publisher -ne $dependency.publisher) {
+    if ($appJson.publisher.Replace(' ', '') -ne $dependency.publisher.Replace(' ', '')) {
         Write-Host "Dependency $($dependency.name) is from different publisher ($($dependency.publisher)) than the main app ($($appJson.publisher)), using exact version match."
         return "[$($dependency.version)]"
     }

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -5,8 +5,11 @@ function GetDependencyVersionFilter {
         [Parameter(Mandatory = $true)]
         [PSCustomObject] $dependency
     )
+    if ($dependency.publisher -eq 'Microsoft') {
+        return ""
+    }
     if ($appJson.publisher -ne $dependency.publisher) {
-        return "" # Use standard logic
+        return "[$($dependency.version)]"
     }
     $versionParts = $appJson.application.Split('.')
     $versionParts[1] = ([int]$versionParts[1] + 1).ToString().PadLeft(2, '0')

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -6,12 +6,15 @@ function GetDependencyVersionFilter {
         [PSCustomObject] $dependency
     )
     if ($dependency.publisher -eq 'Microsoft') {
+        Write-Host "Dependency $($dependency.name) is from Microsoft, no version filter applied."
         return ""
     }
     if ($appJson.publisher -ne $dependency.publisher) {
+        Write-Host "Dependency $($dependency.name) is from different publisher ($($dependency.publisher)) than the main app ($($appJson.publisher)), using exact version match."
         return "[$($dependency.version)]"
     }
     $versionParts = $appJson.application.Split('.')
     $versionParts[1] = ([int]$versionParts[1] + 1).ToString().PadLeft(2, '0')
+    Write-Host "Dependency $($dependency.name) is from the same publisher ($($dependency.publisher)) as the main app ($($appJson.publisher)), using version range [$($dependency.version),$($versionParts[0])$($versionParts[1]).0.0.0)."
     return "[$($dependency.version),$($versionParts[0])$($versionParts[1]).0.0.0)"
 }

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -9,6 +9,6 @@ function GetDependencyVersionFilter {
         return "" # Use standard logic
     }
     $versionParts = $appJson.application.Split('.')
-    $versionParts[1] = ([int]$versionParts[1] + 1).ToString()
+    $versionParts[1] = ([int]$versionParts[1] + 1).ToString().PadLeft(2, '0')
     return "[$($dependency.version),$($versionParts[0])$($versionParts[1]).0.0.0)"
 }

--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -115,7 +115,7 @@ foreach ($dependency in $appJsonContent.dependencies) {
     }
     else {
         . (Join-Path -Path $PSScriptRoot -ChildPath "..\..\CustomLogic\GetDependencyVersionFilter.ps1" -Resolve)
-        $dependencyVersionFilter = GetDependencyVersionFilter -appJson $dependency -installedApp $null -installMode $null
+        $dependencyVersionFilter = GetDependencyVersionFilter -appJson $appJsonContent -dependency $dependency
         if ($dependencyVersionFilter -ne '') {
             OutputDebug -Message "Using custom dependency version filter '$dependencyVersionFilter' for dependency $($dependency.name)."
         }

--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -38,7 +38,7 @@ else {
     $buildCacheFolder = "$baseRepoFolder\.buildpackages"
     if (!(Test-Path $buildCacheFolder)) {
         New-Item -Path $buildCacheFolder -ItemType Directory | Out-Null
-    }appJsonContent
+    }
     
     if ($ENV:AL_RUNWITH -eq "NuGet") {
         $parameters = @{

--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -42,12 +42,12 @@ else {
     
     if ($ENV:AL_RUNWITH -eq "NuGet") {
         $parameters = @{
-            "trustedNugetFeeds"    = $trustedNuGetFeedsMicrosoft
-            "packageName"          = $applicationPackage
-            "appSymbolsFolder"     = $buildCacheFolder
-            "downloadDependencies" = "Microsoft"
-            "select"               = "Latest"
-            "originalAppPublisher" = $appJsonContent
+            "trustedNugetFeeds"      = $trustedNuGetFeedsMicrosoft
+            "packageName"            = $applicationPackage
+            "appSymbolsFolder"       = $buildCacheFolder
+            "downloadDependencies"   = "Microsoft"
+            "select"                 = "Latest"
+            "originalAppJsonContent" = $appJsonContent
         }
 
         $downloadedPackage = @()
@@ -96,10 +96,10 @@ foreach ($dependency in $appJsonContent.dependencies) {
         $trustedNuGetFeedsDependencies = $trustedNuGetFeedsMicrosoft
     }
     $parameters = @{
-        "trustedNugetFeeds"    = $trustedNuGetFeedsDependencies
-        "appSymbolsFolder"     = $dependenciesPackageCachePath
-        "downloadDependencies" = $downloadDependencies
-        "originalAppPublisher" = $appJsonContent
+        "trustedNugetFeeds"      = $trustedNuGetFeedsDependencies
+        "appSymbolsFolder"       = $dependenciesPackageCachePath
+        "downloadDependencies"   = $downloadDependencies
+        "originalAppJsonContent" = $appJsonContent
     }
     if ($ENV:AL_ALLOWPRERELEASE -eq "true") {
         # If enabled, we allow pre-release versions of dependencies.

--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -38,7 +38,7 @@ else {
     $buildCacheFolder = "$baseRepoFolder\.buildpackages"
     if (!(Test-Path $buildCacheFolder)) {
         New-Item -Path $buildCacheFolder -ItemType Directory | Out-Null
-    }
+    }appJsonContent
     
     if ($ENV:AL_RUNWITH -eq "NuGet") {
         $parameters = @{
@@ -47,7 +47,7 @@ else {
             "appSymbolsFolder"     = $buildCacheFolder
             "downloadDependencies" = "Microsoft"
             "select"               = "Latest"
-            "originalAppPublisher" = $appJsonContent.publisher
+            "originalAppPublisher" = $appJsonContent
         }
 
         $downloadedPackage = @()
@@ -99,7 +99,7 @@ foreach ($dependency in $appJsonContent.dependencies) {
         "trustedNugetFeeds"    = $trustedNuGetFeedsDependencies
         "appSymbolsFolder"     = $dependenciesPackageCachePath
         "downloadDependencies" = $downloadDependencies
-        "originalAppPublisher" = $appJsonContent.publisher
+        "originalAppPublisher" = $appJsonContent
     }
     if ($ENV:AL_ALLOWPRERELEASE -eq "true") {
         # If enabled, we allow pre-release versions of dependencies.

--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -47,6 +47,7 @@ else {
             "appSymbolsFolder"     = $buildCacheFolder
             "downloadDependencies" = "Microsoft"
             "select"               = "Latest"
+            "originalAppPublisher" = $appJsonContent.publisher
         }
 
         $downloadedPackage = @()
@@ -98,6 +99,7 @@ foreach ($dependency in $appJsonContent.dependencies) {
         "trustedNugetFeeds"    = $trustedNuGetFeedsDependencies
         "appSymbolsFolder"     = $dependenciesPackageCachePath
         "downloadDependencies" = $downloadDependencies
+        "originalAppPublisher" = $appJsonContent.publisher
     }
     if ($ENV:AL_ALLOWPRERELEASE -eq "true") {
         # If enabled, we allow pre-release versions of dependencies.

--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -47,19 +47,18 @@ else {
             "appSymbolsFolder"       = $buildCacheFolder
             "downloadDependencies"   = "Microsoft"
             "select"                 = "Latest"
-            "originalAppJsonContent" = $appJsonContent
         }
 
         $downloadedPackage = @()
         if ($artifact.ToLower() -eq "////latest") {
-            $downloadedPackage = Get-BCDevOpsFlowsNuGetPackageToFolder @parameters
+            $downloadedPackage = Get-BCDevOpsFlowsNuGetPackageToFolder -originalAppJsonContent $appJsonContent @parameters
         } 
         elseif ($isAppJsonArtifact) {
             $parameters += @{
                 "version" = $applicationVersionFilter
             }
             OutputDebug -Message "Using application version filter '$applicationVersionFilter' for application package."
-            $downloadedPackage = Get-BCDevOpsFlowsNuGetPackageToFolder @parameters
+            $downloadedPackage = Get-BCDevOpsFlowsNuGetPackageToFolder -originalAppJsonContent $appJsonContent @parameters
         }
         else {
             throw "Invalid artifact setting ($artifact) in app.json. The artifact can only be '////latest' or '////appJson'."
@@ -99,7 +98,6 @@ foreach ($dependency in $appJsonContent.dependencies) {
         "trustedNugetFeeds"      = $trustedNuGetFeedsDependencies
         "appSymbolsFolder"       = $dependenciesPackageCachePath
         "downloadDependencies"   = $downloadDependencies
-        "originalAppJsonContent" = $appJsonContent
     }
     if ($ENV:AL_ALLOWPRERELEASE -eq "true") {
         # If enabled, we allow pre-release versions of dependencies.
@@ -133,7 +131,7 @@ foreach ($dependency in $appJsonContent.dependencies) {
 
     $packageName = Get-BCDevOpsFlowsNuGetPackageId -id $dependency.id -name $dependency.name -publisher $dependency.publisher
     Write-Host "Getting $($dependency.name) using name $($dependency.id)"
-    $downloadedPackage = Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $packageName @parameters
+    $downloadedPackage = Get-BCDevOpsFlowsNuGetPackageToFolder -packageName $packageName -originalAppJsonContent $appJsonContent @parameters
 
     if (!$downloadedPackage -or $downloadedPackage.Count -eq 0) {
         throw "No package found for dependency $($dependency.name) with id $($dependency.id) and version $($dependency.version)."

--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -116,13 +116,16 @@ foreach ($dependency in $appJsonContent.dependencies) {
     else {
         . (Join-Path -Path $PSScriptRoot -ChildPath "..\..\CustomLogic\GetDependencyVersionFilter.ps1" -Resolve)
         $dependencyVersionFilter = GetDependencyVersionFilter -appJson $dependency -installedApp $null -installMode $null
-        if ($dependencyVersionFilter -eq '') {
+        if ($dependencyVersionFilter -ne '') {
+            OutputDebug -Message "Using custom dependency version filter '$dependencyVersionFilter' for dependency $($dependency.name)."
+        }
+        else {
             # For all other use cases, we use the version specified in the dependency (or newer).
             $dependencyVersionFilter = "[$($dependency.version),)"
             OutputDebug -Message "Using dependency version filter '$dependencyVersionFilter' for dependency $($dependency.name)."
-            $parameters += @{
-                "version" = $dependencyVersionFilter
-            }
+        }
+        $parameters += @{
+            "version" = $dependencyVersionFilter
         }
     }
 

--- a/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
+++ b/DeterminePackages/ForNuGet/DetermineNugetPackages.ps1
@@ -114,11 +114,15 @@ foreach ($dependency in $appJsonContent.dependencies) {
         }
     }
     else {
-        # For all other use cases, we use the version specified in the dependency (or newer).
-        $dependencyVersionFilter = "[$($dependency.version),)"
-        OutputDebug -Message "Using dependency version filter '$dependencyVersionFilter' for dependency $($dependency.name)."
-        $parameters += @{
-            "version" = $dependencyVersionFilter
+        . (Join-Path -Path $PSScriptRoot -ChildPath "..\..\CustomLogic\GetDependencyVersionFilter.ps1" -Resolve)
+        $dependencyVersionFilter = GetDependencyVersionFilter -appJson $dependency -installedApp $null -installMode $null
+        if ($dependencyVersionFilter -eq '') {
+            # For all other use cases, we use the version specified in the dependency (or newer).
+            $dependencyVersionFilter = "[$($dependency.version),)"
+            OutputDebug -Message "Using dependency version filter '$dependencyVersionFilter' for dependency $($dependency.name)."
+            $parameters += @{
+                "version" = $dependencyVersionFilter
+            }
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new mechanism for customizing dependency version selection by allowing injection of custom logic via the `GetDependencyVersionFilter.ps1` script. It modifies several scripts to pass the original `app.json` content through the dependency resolution pipeline, enabling more flexible and context-aware version filtering for NuGet package dependencies.

Key changes include:

### Custom Dependency Version Filtering

* Added a new script, `CustomLogic/GetDependencyVersionFilter.ps1`, which defines a `GetDependencyVersionFilter` function for custom logic to determine dependency version filters based on the application and dependency metadata.
* Updated `Get-BCDevOpsFlowsNuGetPackageToFolder` to invoke the custom version filter and use its result when resolving dependencies, falling back to default logic if no custom filter is provided.

### Passing Context Through the Pipeline

* Modified parameters for `Get-BCDevOpsFlowsNuGetPackageToFolder` and `Publish-BCDevOpsFlowsNuGetPackageToContainer` to accept and forward the original `app.json` content, ensuring that custom version filtering has the necessary context. [[1]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L74-R75) [[2]](diffhunk://#diff-633feba1be358ad5f735b82698771f9292cbed375d0c5d39cb2141d6db456c2cL58-R59)
* Updated all relevant internal calls to these functions to include the new `originalAppJsonContent` parameter. [[1]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L100-R106) [[2]](diffhunk://#diff-633feba1be358ad5f735b82698771f9292cbed375d0c5d39cb2141d6db456c2cL86-R87) [[3]](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536L54-R61) [[4]](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536R116-R134)

### Integration in Package Determination

* Integrated the custom dependency version filter into the package determination logic in `DetermineNugetPackages.ps1`, so that dependency resolution respects any custom filters provided.

These changes provide a flexible foundation for advanced dependency management scenarios, such as enforcing organization-specific versioning policies or handling complex dependency graphs.