### PR TITLE
Release 0.03.04 gamma 4

### DIFF
--- a/.Internal/ApplyAppJsonUpdates.Helper.ps1
+++ b/.Internal/ApplyAppJsonUpdates.Helper.ps1
@@ -95,8 +95,8 @@ function UpdateVersion {
     $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
 
     $existingVersionAsArray = [Version]$appFileJson.version
-    $appBuild = if ($settings.appBuild -eq -1) { $existingVersionAsArray.Build } else { $settings.appBuild }
-    $appRevision = if ($settings.appRevision -eq -1) { $existingVersionAsArray.Revision } else { $settings.appRevision }
+    $appBuild = if ($settings.appBuild -eq -1 -or $null -eq $settings.appBuild) { $existingVersionAsArray.Build } else { $settings.appBuild }
+    $appRevision = if ($settings.appRevision -eq -1 -or $null -eq $settings.appRevision) { $existingVersionAsArray.Revision } else { $settings.appRevision }
 
     $appFileJson.version = "$($existingVersionAsArray.Major).$($existingVersionAsArray.Minor).$appBuild.$appRevision"       
     Write-Host "Updating app.json version to $($appFileJson.version)"

--- a/.Internal/NuGet/Publish-BCDevOpsFlowsNuGetPackageToContainer.ps1
+++ b/.Internal/NuGet/Publish-BCDevOpsFlowsNuGetPackageToContainer.ps1
@@ -55,7 +55,8 @@ Function Publish-BCDevOpsFlowsNuGetPackageToContainer {
         [string] $appSymbolsFolder = "",
         [string] $copyInstalledAppsToFolder = "",
         [switch] $allowPrerelease,
-        [switch] $skipVerification
+        [switch] $skipVerification,
+        [string] $originalAppJsonContent
     )
 
     if ($containerName -eq "" -and (!($bcAuthContext -and $environment))) {
@@ -83,7 +84,7 @@ Function Publish-BCDevOpsFlowsNuGetPackageToContainer {
         else {
             Write-Host "Prereleased packages are not allowed"
         }
-        if (Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -appSymbolsFolder $tmpFolder -installedApps $installedApps -installedPlatform $installedPlatform -installedCountry $installedCountry -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease ) {
+        if (Get-BCDevOpsFlowsNuGetPackageToFolder -trustedNugetFeeds $trustedNugetFeeds -packageName $packageName -version $version -originalAppJsonContent $originalAppJsonContent -appSymbolsFolder $tmpFolder -installedApps $installedApps -installedPlatform $installedPlatform -installedCountry $installedCountry -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease ) {
             $appFiles = Get-Item -Path (Join-Path $tmpFolder '*.app') | ForEach-Object {
                 if ($appSymbolsFolder) {
                     Copy-Item -Path $_.FullName -Destination $appSymbolsFolder -Force

--- a/CustomLogic/GetDependencyVersionFilter.ps1
+++ b/CustomLogic/GetDependencyVersionFilter.ps1
@@ -1,0 +1,9 @@
+function GetDependencyVersionFilter {
+    Param(
+        [Parameter(Mandatory = $true)]
+        [PSCustomObject] $appJson,
+        [Parameter(Mandatory = $true)]
+        [PSCustomObject] $dependency
+    )
+    return ""
+}

--- a/DeliverAppFile/DeliverAppFile.ps1
+++ b/DeliverAppFile/DeliverAppFile.ps1
@@ -62,7 +62,10 @@ try {
             }
 
             foreach ($folderName in $folders) {
-                Push-AppToNuGetFeed -folderName $folderName -url $deliverToContext.Url -token $deliverToContext.Token -versionSuffix $versionSuffix
+                $testFolder = Join-Path -Path $ENV:BUILD_REPOSITORY_LOCALPATH -ChildPath $folderName
+                if (Test-Path $testFolder) {
+                    Push-AppToNuGetFeed -folderName $folderName -url $deliverToContext.Url -token $deliverToContext.Token -versionSuffix $versionSuffix
+                }
             }
         }
     }

--- a/DeterminePackages/DeterminePackages.Helper.ps1
+++ b/DeterminePackages/DeterminePackages.Helper.ps1
@@ -183,6 +183,9 @@ function Update-CustomCodeCops {
             $majorVersion = [Version]::Parse($appJson.application).Major
             # https://github.com/StefanMaron/BusinessCentral.LinterCop/releases/latest/download/BusinessCentral.LinterCop.dll
             switch ($majorVersion) {
+                28 { $linterCopURL = "BusinessCentral.LinterCop.AL-17.0.1825603.dll" }
+                # 27 as default
+                26 { $linterCopURL = "BusinessCentral.LinterCop.AL-15.2.1630495.dll" }
                 25 { $linterCopURL = "BusinessCentral.LinterCop.AL-14.3.1327807.dll" }
                 24 { $linterCopURL = "BusinessCentral.LinterCop.AL-13.1.1065068.dll" }
                 23 { $linterCopURL = "BusinessCentral.LinterCop.AL-12.7.964847.dll" }


### PR DESCRIPTION
This pull request introduces custom logic for filtering dependency versions when downloading NuGet packages, and propagates the original `app.json` content through several scripts to support this feature. It also adds support for newer Business Central versions in linter cop selection and improves robustness in version handling and app delivery.

**Custom Dependency Version Filtering**

* Added a new script `CustomLogic/GetDependencyVersionFilter.ps1` with a `GetDependencyVersionFilter` function, allowing custom logic to determine dependency version filters. This is now invoked in both `DetermineNugetPackages.ps1` and `Get-BCDevOpsFlowsNuGetPackageToFolder.ps1` to override default dependency version selection if needed. [[1]](diffhunk://#diff-99341fb11e6bd61c1bc89a08dcdd12fe283f19e9ea00337e00a6c53703b93a77R1-R9) [[2]](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536R116-R134) [[3]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L271-R288)
* The original `app.json` content is now passed as a parameter (`-originalAppJsonContent`) through several scripts and function calls, enabling the custom logic to access relevant context for dependency version filtering. [[1]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L74-R75) [[2]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L100-R106) [[3]](diffhunk://#diff-f1d508b24057a2e884e9c42a27eb40e03ec2cf7737e0daff6da96efa26d6ebe7L271-R288) [[4]](diffhunk://#diff-633feba1be358ad5f735b82698771f9292cbed375d0c5d39cb2141d6db456c2cL58-R59) [[5]](diffhunk://#diff-633feba1be358ad5f735b82698771f9292cbed375d0c5d39cb2141d6db456c2cL86-R87) [[6]](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536L54-R61) [[7]](diffhunk://#diff-ff8f16a1c735e156b800873241b337c727bd9d4ea76419b2705578c007283536R116-R134)

**Business Central Version Support**

* Updated linter cop selection logic in `DeterminePackages.Helper.ps1` to support Business Central version 28 and 26, ensuring the correct linter cop DLL is chosen for those versions.

**Robustness and Miscellaneous Improvements**

* Improved version handling in `ApplyAppJsonUpdates.Helper.ps1` so that build and revision numbers default to existing values if they are not set or are null, reducing the risk of errors during version update.
* Enhanced delivery logic in `DeliverAppFile.ps1` to check for folder existence before attempting to push apps, preventing errors if a folder is missing.