### PR TITLE
Versioning strategy10 with NuGet

### DIFF
--- a/.Internal/ApplyAppJsonUpdates.Helper.ps1
+++ b/.Internal/ApplyAppJsonUpdates.Helper.ps1
@@ -95,8 +95,8 @@ function UpdateVersion {
     $appFileJson = Get-AppJsonFile -sourceAppJsonFilePath $appJsonFilePath
 
     $existingVersionAsArray = [Version]$appFileJson.version
-    $appBuild = if ($settings.appBuild -eq -1) { $existingVersionAsArray.Build } else { $settings.appBuild }
-    $appRevision = if ($settings.appRevision -eq -1) { $existingVersionAsArray.Revision } else { $settings.appRevision }
+    $appBuild = if ($settings.appBuild -eq -1 -or $null -eq $settings.appBuild) { $existingVersionAsArray.Build } else { $settings.appBuild }
+    $appRevision = if ($settings.appRevision -eq -1 -or $null -eq $settings.appRevision) { $existingVersionAsArray.Revision } else { $settings.appRevision }
 
     $appFileJson.version = "$($existingVersionAsArray.Major).$($existingVersionAsArray.Minor).$appBuild.$appRevision"       
     Write-Host "Updating app.json version to $($appFileJson.version)"


### PR DESCRIPTION
This pull request makes a small but important update to the version update logic in the `UpdateVersion` function. The change ensures that if either `appBuild` or `appRevision` is not set (i.e., is `$null`), the existing value from the version is retained, improving robustness when handling unset values.

- Improved version update logic in `UpdateVersion` to handle `$null` values for `appBuild` and `appRevision`, ensuring existing version components are preserved if not explicitly set. (.Internal/ApplyAppJsonUpdates.Helper.ps1)