### PR TITLE
Custom run custom cleanup

### DIFF
--- a/CustomLogic/RunCustomCleanup.ps1
+++ b/CustomLogic/RunCustomCleanup.ps1
@@ -1,0 +1,3 @@
+function RunCustomCleanup {
+    Param()
+}

--- a/PipelineCleanup/PipelineCleanup.ps1
+++ b/PipelineCleanup/PipelineCleanup.ps1
@@ -31,6 +31,9 @@ try {
             Remove-Item $cleanUpPath -Recurse -Include *.*
         }
     }
+    
+    . (Join-Path -Path $PSScriptRoot -ChildPath "..\CustomLogic\RunCustomCleanup.ps1" -Resolve)
+    RunCustomCleanup
 }
 catch {
     Write-Host "##vso[task.logissue type=error]$($_.Exception.Message)"


### PR DESCRIPTION
This pull request introduces a mechanism for running custom cleanup logic in the pipeline cleanup process by adding a placeholder function and invoking it from the main cleanup script.

Integration of custom cleanup logic:

* Added a new script `RunCustomCleanup.ps1` in the `CustomLogic` directory, which defines an empty `RunCustomCleanup` function as a placeholder for future custom cleanup steps.
* Updated `PipelineCleanup.ps1` to import and invoke the `RunCustomCleanup` function after the standard cleanup steps, allowing for extensibility via custom logic.