### PR TITLE
Fix read settings for setup pipeline step (#239)

### DIFF
--- a/ReadSettings/ReadSettings.ps1
+++ b/ReadSettings/ReadSettings.ps1
@@ -119,20 +119,24 @@ try {
     $ENV:AL_SETTINGS = $($outSettings | ConvertTo-Json -Depth 99 -Compress)
     Write-Host "##vso[task.setvariable variable=AL_SETTINGS;]$($outSettings | ConvertTo-Json -Depth 99 -Compress)"
     OutputDebug -Message "Set environment variable AL_SETTINGS to ($ENV:AL_SETTINGS)"
-    $isAppJsonArtifact = $outSettings.artifact.ToLowerInvariant() -eq "////appjson"
-    $ENV:AL_APPJSONARTIFACT = $isAppJsonArtifact
-    Write-Host "##vso[task.setvariable variable=AL_APPJSONARTIFACT;]$isAppJsonArtifact"
-    OutputDebug -Message "Set environment variable AL_APPJSONARTIFACT to ($ENV:AL_APPJSONARTIFACT)"
 
     # Identify artifact
-    if ($runWith -eq 'bccontainerhelper') {
-        . (Join-Path -Path $PSScriptRoot -ChildPath "ForBCContainerHelper\DetermineArtifactUrl.ps1" -Resolve)
-    }
-    elseif ($runWith -eq 'nuget') {
-        . (Join-Path -Path $PSScriptRoot -ChildPath "ForNuGet\DetermineMajorVersion.ps1" -Resolve)
-    }
-    else {
-        throw "Unknown AL_RUNWITH value: $runWith. Supported values are 'NuGet' and 'BCContainerHelper'."
+    if ($ENV:AL_PIPELINENAME -ne "SetupPipelines") {
+        $isAppJsonArtifact = $outSettings.artifact.ToLowerInvariant() -eq "////appjson"
+        $ENV:AL_APPJSONARTIFACT = $isAppJsonArtifact
+        Write-Host "##vso[task.setvariable variable=AL_APPJSONARTIFACT;]$isAppJsonArtifact"
+        OutputDebug -Message "Set environment variable AL_APPJSONARTIFACT to ($ENV:AL_APPJSONARTIFACT)"
+
+        # Identify artifact
+        if ($runWith -eq 'bccontainerhelper') {
+            . (Join-Path -Path $PSScriptRoot -ChildPath "ForBCContainerHelper\DetermineArtifactUrl.ps1" -Resolve)
+        }
+        elseif ($runWith -eq 'nuget') {
+            . (Join-Path -Path $PSScriptRoot -ChildPath "ForNuGet\DetermineMajorVersion.ps1" -Resolve)
+        }
+        else {
+            throw "Unknown AL_RUNWITH value: $runWith. Supported values are 'NuGet' and 'BCContainerHelper'."
+        }
     }
 }
 catch {


### PR DESCRIPTION
This pull request introduces a minor enhancement to the settings reading logic in `ReadSettings/ReadSettings.ps1`. The main change is the addition of a conditional check to identify artifacts only when the pipeline is not `SetupPipelines`.

Settings handling improvements:

* Added a condition to skip artifact identification logic if the environment variable `AL_PIPELINENAME` is set to `SetupPipelines`, ensuring artifact detection only occurs for relevant pipelines.
* Moved the closing brace for the `try` block to properly encapsulate the new conditional logic.